### PR TITLE
Add Vault-Transit client support.

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/Base64.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Base64.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import cats.{ApplicativeError, Eq}
+import cats.kernel.instances.string._
+import cats.instances.either._
+import io.circe.{Encoder, Decoder, Json}
+import scodec.bits.{ByteVector, BitVector}
+
+/** A String wrapper class, to ensure that the string inside is a valid
+  *  Base64 string, as those used in Vault to represent plaintext and context. 
+  */
+final class Base64 private[Base64] (val value: String) extends AnyVal {
+  override def toString = s"Base64($value)"
+}
+
+object Base64 {
+
+  implicit val eqBase64: Eq[Base64] = Eq.by[Base64, String](_.value)
+
+  implicit final val decodeBase64: Decoder[Base64] =
+    Decoder[String].emap(Base64.fromString[Either[String, ?]])
+  implicit final val encodeBase64: Encoder[Base64] =
+    Encoder.instance(bv => Json.fromString(bv.value))
+
+
+  /** A cost-free predicate to check if a String is a valid encoding outcome as described in
+    * https://tools.ietf.org/html/rfc4648#section-4. 
+    * 
+    * Meaning: its length is a multiple of 4, and all its characters are letters, digits, '+' or '/'. 
+    * Except at the end, where either: a) the last two characters can both be padding `=``; 
+    *  or b) only the last character is padding; or c) no character is padding.   */
+  private[transit] def isBase64(str: String): Boolean =
+    (str.length & 3) == 0 && {
+      (str.length - str.count(isBase64)) match {
+        case 0 => true
+        case 1 => isPadding(str.charAt(str.length -1))
+        case 2 => isPadding(str.charAt(str.length -1)) && isPadding(str.charAt(str.length - 2))
+        case _ => false
+      }
+    }
+
+  private def isBase64(char: Char): Boolean = char.isLetterOrDigit || char == '/' || char == '+'
+  private def isPadding(char: Char): Boolean = char == '='
+
+  def fromStringOpt(str: String): Option[Base64] =
+    if (isBase64(str)) Some(new Base64(str)) else None
+  
+  def fromString[F[_]](str: String)(implicit F: ApplicativeError[F, String]): F[Base64] =
+    if (isBase64(str)) F.pure(new Base64(str))
+    else F.raiseError(s"""The string "$str" is not a valid Base-64 encoded literal""")
+
+  def fromByteVector(bv: ByteVector): Base64 = new Base64(bv.toBase64)
+
+  def fromBitVector(bv: BitVector): Base64 = new Base64(bv.toBase64)
+
+  private[transit] def unsafeFrom(str: String): Base64 = new Base64(str)
+}

--- a/core/src/main/scala/com/banno/vault/transit/Transit.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Transit.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import cats.syntax.all._
+import cats.effect.Sync
+import org.http4s._
+import org.http4s.Method.{GET, POST}
+import org.http4s.client.Client
+import com.banno.vault.models.VaultRequestError
+import io.circe.Encoder
+import org.http4s.circe._
+
+object Transit {
+
+  /** Function to get the details and information of a transit Key, such as the cipher being used,
+    *  and whether it supports convergent encryption.
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#read-key
+    */
+  def keyDetails[F[_]: Sync]
+    (client: Client[F], vaultUri: Uri, token: String, key: KeyName)
+      : F[KeyDetails] =
+    new TransitClient[F](client, vaultUri, token, key).keyDetails
+
+  /**  Function to encrypt data.
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#encrypt-data
+    */
+  def encrypt[F[_]: Sync]
+    (client: Client[F], vaultUri: Uri, token: String, key: KeyName)
+    (plaintext: PlainText)
+      : F[CipherText] =
+    new TransitClient[F](client, vaultUri, token, key).encrypt(plaintext)
+
+  /**  Function to encrypt data.
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#encrypt-data
+    */
+  def encryptInContext[F[_]: Sync]
+    (client: Client[F], vaultUri: Uri, token: String, key: KeyName)
+    (plaintext: PlainText, context: Context)
+      : F[CipherText] =
+    new TransitClient[F](client, vaultUri, token, key).encryptInContext(plaintext, context)
+
+  /**  Function to decrypt data.
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#decrypt-data
+    */
+  def decrypt[F[_]: Sync]
+    (client: Client[F], vaultUri: Uri, token: String, key: KeyName)
+    (cipherText: CipherText)
+      : F[PlainText] =
+    new TransitClient[F](client, vaultUri, token, key).decrypt(cipherText)
+
+  /**  Function to decrypt data, given some context information.
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#decrypt-data
+    */
+  def decryptInContext[F[_]: Sync]
+    (client: Client[F], vaultUri: Uri, token: String, key: KeyName)
+    (cipherText: CipherText, context: Context)
+      : F[PlainText] =
+    new TransitClient[F](client, vaultUri, token, key).decryptInContext(cipherText, context)
+
+
+}
+
+/**
+ * A TransitClient represents an authenticated connection to a vault transit service.
+ * The way we see to use it is that, in your application you may have a certain type of data
+ * that you want to encrypt or decrypt using Vault transit, with a key that is fixed for that data.
+ */
+final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String, key: KeyName)(implicit F: Sync[F]) {
+
+  private implicit val encryptResponseEntityDecoder: EntityDecoder[F, EncryptResponse] = jsonOf
+  private implicit val decryptResponseEntityDecoder: EntityDecoder[F, DecryptResponse] = jsonOf
+  private implicit val keyEntityDecoder: EntityDecoder[F, KeyDetails] = jsonOf
+
+  /* The URIs we use here are those from the transit documentation.
+   * the v1 prefix is specified in https://www.vaultproject.io/api/overview
+   */
+  private val encryptUri: Uri =  vaultUri / "v1" / "transit" / "encrypt" / key.name
+  private val decryptUri: Uri =  vaultUri / "v1" / "transit" / "decrypt" / key.name
+  private val readKeyUri: Uri =  vaultUri / "v1" / "transit" / "keys"    / key.name
+
+  private val tokenHeaders: Headers = Headers.of(Header("X-Vault-Token", token))
+
+  private def doRequest[A](uri: Uri, data: A)(implicit enc: Encoder[A])  =
+    Request[F](method = POST, uri = uri, headers = tokenHeaders).withEntity(enc(data))
+
+  /** Function to access the details of a transit Key
+    *
+    * https://www.vaultproject.io/api/secret/transit/index.html#read-key
+    */
+  val keyDetails: F[KeyDetails] = {
+    val request = Request[F](method = GET, uri = readKeyUri, headers = tokenHeaders)
+    F.handleErrorWith(client.expect[KeyDetails](request)){ e =>
+      F.raiseError(VaultRequestError(request, e.some, s"keyName=${key.name}".some))
+    }
+  }
+
+  /**  Function to encrypt data, given the name of the secret
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#encrypt-data
+    */
+  def encrypt(plaintext: PlainText): F[CipherText] = {
+    val encryptReq = EncryptRequest(plaintext, None)
+    val request = doRequest(encryptUri, encryptReq)
+    for {
+      response <- F.handleErrorWith(client.expect[EncryptResponse](request)){ e =>
+        F.raiseError(VaultRequestError(request, e.some, s"keyName=${key.name}".some))
+      }
+    } yield response.data.ciphertext
+  }
+
+  /**  Function to encrypt data, adding a context for key derivation.
+    *
+    *  https://www.vaultproject.io/api/secret/transit/index.html#encrypt-data
+    */
+  def encryptInContext(plaintext: PlainText, context: Context): F[CipherText] = {
+    val encryptReq = EncryptRequest(plaintext, Some(context))
+    val request = doRequest(encryptUri, encryptReq)
+    for {
+      response <- F.handleErrorWith(client.expect[EncryptResponse](request)){ e =>
+        F.raiseError(VaultRequestError(request, e.some, s"keyName=${key.name}, context = ${context.context.value}".some))
+      }
+    } yield response.data.ciphertext
+  }
+
+  /** https://www.vaultproject.io/api/secret/transit/index.html#decrypt-data
+   *
+   */
+  def decrypt(cipherText: CipherText): F[PlainText] = {
+    val decryptReq = DecryptRequest(cipherText, None)
+    val request = doRequest(decryptUri, decryptReq)
+    for {
+      response <- F.handleErrorWith(client.expect[DecryptResponse](request)){ e =>
+        F.raiseError(VaultRequestError(request, e.some, s"keyName=${key.name}".some))
+      }
+    } yield response.data.plaintext
+  }
+
+  /** https://www.vaultproject.io/api/secret/transit/index.html#decrypt-data
+   *
+  */
+  def decryptInContext(cipherText: CipherText, context: Context): F[PlainText] = {
+    val decryptReq = DecryptRequest(cipherText, Some(context))
+    val request = doRequest(decryptUri, decryptReq)
+    for {
+      response <- F.handleErrorWith(client.expect[DecryptResponse](request)){ e =>
+        val showCtx = context.context.value
+        F.raiseError(VaultRequestError(request, e.some, s"keyName=${key.name}, context = $showCtx".some))
+      }
+    } yield response.data.plaintext
+  }
+
+}

--- a/core/src/main/scala/com/banno/vault/transit/models.scala
+++ b/core/src/main/scala/com/banno/vault/transit/models.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import cats.Eq
+import cats.kernel.instances.option._
+import cats.kernel.instances.string._
+import cats.syntax.eq._
+import io.circe.{Decoder, Encoder, Json}
+import java.time.Instant
+
+final case class KeyName(name: String)
+final case class KeyDetails(
+  name: String,
+  isConvergent: Boolean,
+  isDerived: Boolean,
+  versions: Map[Int, Instant],
+  cipher: String
+)
+
+object KeyDetails {
+
+  implicit final val encodeKeyDetails: Encoder[KeyDetails] =
+    Encoder.instance { (kd: KeyDetails) => Json.obj(
+      "data" -> Json.obj(
+        "name"                  -> Json.fromString(kd.name),
+        "type"                  -> Json.fromString(kd.cipher),
+        "convergent_encryption" -> Json.fromBoolean(kd.isConvergent),
+        "derived"               -> Json.fromBoolean(kd.isDerived),
+        "keys"                  -> Json.fromFields(
+          kd.versions.map { case (num, inst) =>
+            num.toString -> Json.fromLong(inst.getEpochSecond)
+          }
+        )
+      )
+    )}
+
+    implicit final val decodeKeyDetails: Decoder[KeyDetails] = {
+      implicit val decodeInstantSecond: Decoder[Instant] =
+        Decoder.decodeLong.emap { numsec =>
+          if (numsec <= Instant.MAX.getEpochSecond)
+            Right(Instant.ofEpochSecond(numsec))
+          else Left(s"value $numsec of UNIX epoch seconds is over Java maximum Instant")
+        }
+      Decoder.instance[KeyDetails] { c =>
+        Decoder.resultInstance.map5(
+          c.downField("data").downField("name").as[String],
+          c.downField("data").downField("convergent_encryption").as[Boolean],
+          c.downField("data").downField("derived").as[Boolean],
+          c.downField("data").downField("keys").as[Map[Int, Instant]],
+          c.downField("data").downField("type").as[String]
+        )(KeyDetails.apply(_,_,_,_,_))
+      }
+    }
+
+}
+
+/** A tagged-like newtype used to indicate that a Base64 value is a plaintext we want to encrypt.
+  */
+final case class PlainText(plaintext: Base64)
+object PlainText {
+  implicit val eqPlainText: Eq[PlainText] =
+    Eq.by[PlainText, Base64](_.plaintext)
+  private[transit] implicit val encodePlainText: Encoder[PlainText] =
+    Base64.encodeBase64.contramap(_.plaintext)
+  private[transit] implicit val decodePlainText: Decoder[PlainText] =
+    Base64.decodeBase64.map(PlainText.apply)
+}
+
+/** A tagged-like newtype used to indicate that a Base64 value is the user-supplied context used in key derivation.
+  * "Key derivation allows the same key to be used for multiple purposes
+  * by deriving a new key based on a user-supplied context value
+  *
+  * https://www.vaultproject.io/docs/secrets/transit/index.html#transit-secrets-engine
+  */
+final case class Context(context: Base64)
+object Context {
+  implicit val eqContext: Eq[Context] =
+    Eq.by[Context, Base64](_.context)
+  private[transit] implicit val encodeContext: Encoder[Context] =
+    Base64.encodeBase64.contramap(_.context)
+  private[transit] implicit val decodeContext: Decoder[Context] =
+    Base64.decodeBase64.map(Context.apply)
+}
+
+/** In the Vault Transit, cipher-texts are Base64 strings preceded by the `"vault:v1:"` prefix text.
+  * We our special wrapper class to represent Base64 Strings.
+  */
+final case class CipherText(ciphertext: String) extends AnyVal
+object CipherText {
+  private[transit] implicit val encodeCipherText: Encoder[CipherText] =
+    Encoder.encodeString.contramap(_.ciphertext)
+  private[transit] implicit val decodeCipherText: Decoder[CipherText] =
+    Decoder.decodeString.map(CipherText.apply)
+  implicit val eqCipherText: Eq[CipherText] =
+    Eq.by[CipherText, String](_.ciphertext)
+}
+
+final case class EncryptRequest(plaintext: PlainText, context: Option[Context])
+object EncryptRequest {
+  implicit val eqEncryptRequest: Eq[EncryptRequest] =
+    Eq.instance { (x: EncryptRequest, y: EncryptRequest) =>
+      x.context === y.context && x.plaintext === y.plaintext
+    }
+  implicit val encodeEncryptRequest: Encoder[EncryptRequest] =
+    Encoder.forProduct2("plaintext", "context")(er => (er.plaintext, er.context))
+  implicit val decodeEncryptRequest: Decoder[EncryptRequest] =
+    Decoder.forProduct2("plaintext", "context")((pt: PlainText, ct: Option[Context]) => EncryptRequest(pt,ct))
+}
+
+private[transit] final case class EncryptResult(ciphertext: CipherText)
+private[transit] object EncryptResult {
+  implicit val eqEncryptResult: Eq[EncryptResult] = Eq.by(_.ciphertext)
+
+  implicit val encodeEncryptResult: Encoder[EncryptResult] =
+    Encoder.instance { (er: EncryptResult) => Json.obj(
+      "ciphertext" -> Encoder[CipherText].apply(er.ciphertext)
+    )}
+
+  implicit val decodeEncryptResult: Decoder[EncryptResult] =
+    Decoder.forProduct1("ciphertext")((ct: CipherText) => EncryptResult.apply(ct))
+}
+
+private[transit] case class EncryptResponse(data: EncryptResult)
+private[transit] object EncryptResponse {
+  implicit val eqEncryptResponse: Eq[EncryptResponse] =
+    Eq.by[EncryptResponse, EncryptResult](_.data)
+  implicit val encodeEncryptResponse: Encoder[EncryptResponse] =
+    Encoder.forProduct1("data")(_.data)
+  implicit val decodeEncryptResponse: Decoder[EncryptResponse] =
+    Decoder.forProduct1("data")((d: EncryptResult) => EncryptResponse(d))
+}
+
+private[transit] final case class DecryptRequest(ciphertext: CipherText, context: Option[Context])
+private[transit] object DecryptRequest {
+  implicit val eqDecryptRequest: Eq[DecryptRequest] =
+    Eq.instance { (x: DecryptRequest, y: DecryptRequest) =>
+      x.context === y.context && x.ciphertext === y.ciphertext
+    }
+
+  implicit val encodeDecryptRequest: Encoder[DecryptRequest] =
+    Encoder.forProduct2("ciphertext", "context")(dr => (dr.ciphertext, dr.context))
+
+  implicit val decodeDecryptRequest: Decoder[DecryptRequest] =
+    Decoder.forProduct2("ciphertext", "context")((cr: CipherText, ct: Option[Context]) => DecryptRequest(cr, ct))
+}
+
+private[transit] final case class DecryptResult(plaintext: PlainText)
+private[transit] object DecryptResult {
+  implicit val eqDecryptResponse: Eq[DecryptResult] =
+    Eq.by[DecryptResult, PlainText](_.plaintext)
+
+  implicit val encodeDecryptResult: Encoder[DecryptResult] =
+    Encoder.forProduct1("plaintext")(_.plaintext)
+
+  implicit val decodeDecryptResult: Decoder[DecryptResult] =
+    Decoder.forProduct1("plaintext")((pt: PlainText)  => DecryptResult(pt))
+}
+
+private[transit] final case class DecryptResponse(data: DecryptResult)
+private[transit] object DecryptResponse {
+  implicit val eqDecryptResponse: Eq[DecryptResponse] =
+    Eq.by[DecryptResponse, DecryptResult](_.data)
+
+  implicit val encodeDecryptResponse: Encoder[DecryptResponse] =
+    Encoder.forProduct1("data")(_.data)
+  implicit val decodeDecryptResponse: Decoder[DecryptResponse] =
+    Decoder.forProduct1("data")((d: DecryptResult) => DecryptResponse(d))
+}
+
+private[transit] final case class TransitError(error: String)
+private[transit] object TransitError {
+  type Or[A] = Either[TransitError, A]
+
+  implicit val encodeError: Encoder[TransitError] =
+    Encoder.forProduct1("error")(_.error)
+
+  implicit val decodeError: Decoder[TransitError] =
+    Decoder.forProduct1("error")((e: String) => TransitError(e))
+
+  implicit def encodeOr[A](implicit encodeA: Encoder[A]): Encoder[Or[A]] =
+    Encoder.instance {
+      case Left(err) => encodeError(err)
+      case Right(a)  => encodeA(a)
+    }
+
+  implicit def decodeOr[A](implicit decodeA: Decoder[A]): Decoder[Or[A]] =
+    decodeError either decodeA
+
+}

--- a/core/src/test/scala/com/banno/vault/VaultSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.banno.vault
 
 import java.util.UUID

--- a/core/src/test/scala/com/banno/vault/transit/MockTransitService.scala
+++ b/core/src/test/scala/com/banno/vault/transit/MockTransitService.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import cats.syntax.flatMap._
+import cats.syntax.eq._
+import cats.effect.Sync
+import io.circe.Json
+import org.http4s.dsl.Http4sDsl
+import org.http4s.circe._
+import org.http4s.{EntityDecoder, HttpApp, Request, Response}
+import org.http4s.util.CaseInsensitiveString
+
+final class MockTransitService[F[_]: Sync](
+  keyname: String, 
+  token: String,
+  context: Option[Context],
+  encrypted: CipherText,
+  plaintext: PlainText
+) extends Http4sDsl[F] {
+
+  private implicit val encryptRequestEntityDecoder: EntityDecoder[F, EncryptRequest] = jsonOf
+  private implicit val decryptRequestEntityDecoder: EntityDecoder[F, DecryptRequest] = jsonOf
+
+  private def findVaultToken(req: Request[F]): Option[String] =
+    req.headers.find(_.name == CaseInsensitiveString("X-Vault-Token")).map(_.value)
+
+  private def checkVaultToken(req: Request[F])(resp: F[Response[F]]): F[Response[F]] =
+    findVaultToken(req) match {
+      case None => BadRequest(""" {"errors": [ "missing client token"] }""")
+      case Some(`token`) => resp
+      case Some(_) => Forbidden(""" {"errors": [ "permission denied"] }""")
+    }
+
+  val routes: HttpApp[F] = HttpApp.apply[F] { req => 
+    checkVaultToken(req){ req match {
+      case req @ POST -> Root / "v1" / "transit" / "encrypt" / `keyname` =>
+        req.as[EncryptRequest].flatMap{ case encreq =>
+          if (encreq === EncryptRequest(plaintext,context))
+            Ok( Json.obj(
+              "data" -> Json.obj(
+                "ciphertext" -> Json.fromString(encrypted.ciphertext)
+              )
+            ))
+          else
+            Gone()
+        }
+      case req @ POST -> Root / "v1" / "transit" / "decrypt" / `keyname` => 
+        req.as[DecryptRequest].flatMap { case decreq => 
+          if (decreq === DecryptRequest(encrypted, context))
+            Ok( Json.obj(
+              "data" -> Json.obj(
+                "plaintext" -> Json.fromString(plaintext.plaintext.value)
+              )
+            ))
+          else Gone()
+
+        }
+      case _ => NotFound()
+    }}
+  }
+}

--- a/core/src/test/scala/com/banno/vault/transit/ModelsSpec.scala
+++ b/core/src/test/scala/com/banno/vault/transit/ModelsSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import io.circe.Json
+import cats.implicits._
+import org.specs2.{Spec, ScalaCheck}
+import org.specs2.specification.core.SpecStructure
+import org.scalacheck.Prop
+import io.circe.syntax._ 
+
+object TransitModelsSpec extends Spec with ScalaCheck {
+  import TransitGenerators._
+
+  override def is: SpecStructure = s2"""
+      |the Base64 check predicate holds for any ByteVector generated in $isBase64Prop
+      |encode an encrypt request in $encodeEncryptRequestProp
+      |decode an encrypt response in $decodeEncryptResponseProp
+      |encode a  decrypt request in $encodeDecryptRequestProp
+      |decode a  decrypt response in $decodeDecryptResponseProp
+    """.stripMargin
+
+  val isBase64Prop: Prop = Prop.forAll(byteVector){ bv => 
+    Base64.isBase64(bv.toBase64) 
+  }
+
+  val encodeEncryptRequestProp: Prop = 
+    Prop.forAll(base64, base64){ (plaintext: Base64, context: Base64) =>
+      val expected = Json.obj(
+        "plaintext" -> Json.fromString(plaintext.value),
+        "context"   -> Json.fromString(context.value)
+      )
+      val input = EncryptRequest(PlainText(plaintext), Some(Context(context)))
+      input.asJson === expected
+    }
+
+  val decodeEncryptResponseProp: Prop = Prop.forAll(cipherText){ (ct: CipherText) =>
+    val json = Json.obj(
+      "data" -> Json.obj(
+        "ciphertext" -> Json.fromString(ct.ciphertext)
+      )
+    )
+    EncryptResponse.decodeEncryptResponse.decodeJson(json) === Right(EncryptResponse(EncryptResult(ct)))
+  }
+
+  val encodeDecryptRequestProp: Prop =
+    Prop.forAll(cipherText, base64){ (ct: CipherText, context: Base64) =>
+      val expected = Json.obj(
+        "ciphertext" -> Json.fromString(ct.ciphertext),
+        "context"    -> Json.fromString(context.value)
+      )
+      DecryptRequest(ct, Some(Context(context))).asJson === expected
+    }
+
+  val decodeDecryptResponseProp: Prop = Prop.forAll(base64){ (plaintext: Base64) =>
+    val json = Json.obj(
+      "data" -> Json.obj( "plaintext" -> Json.fromString(plaintext.value))
+    )
+    DecryptResponse.decodeDecryptResponse.decodeJson(json) === Right(DecryptResponse(DecryptResult(PlainText(plaintext))))
+  }
+
+}

--- a/core/src/test/scala/com/banno/vault/transit/TransitGenerators.scala
+++ b/core/src/test/scala/com/banno/vault/transit/TransitGenerators.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import com.banno.vault.VaultArbitraries
+import scodec.bits.ByteVector
+import org.scalacheck.Gen
+
+object TransitGenerators extends VaultArbitraries {
+
+  // copied from scodec-bits repository.
+  def standardByteVectors(maxSize: Int): Gen[ByteVector] = for {
+    size <- Gen.choose(0, maxSize)
+    bytes <- Gen.listOfN(size, Gen.choose(0, 255))
+  } yield ByteVector(bytes: _*)
+
+  val byteVector: Gen[ByteVector] = Gen.choose(1, 1000).flatMap(standardByteVectors)
+
+  val base64: Gen[Base64] = byteVector.map(Base64.fromByteVector)
+
+  // we generate examples like we have seen so far: a base64-encoded literal, prefixed by `vault:v1:` 
+  val cipherText: Gen[CipherText] = base64.map( x => CipherText(s"vault:v1:${x.value}"))
+
+}

--- a/core/src/test/scala/com/banno/vault/transit/TransitSpec.scala
+++ b/core/src/test/scala/com/banno/vault/transit/TransitSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.transit
+
+import cats.effect.IO
+import cats.implicits._
+import cats.kernel.Eq
+import java.util.UUID
+import org.http4s.Uri
+import org.http4s.client.Client
+import org.scalacheck.{Gen, Prop}
+import org.specs2.{ScalaCheck, Spec}
+import org.specs2.specification.core.SpecStructure
+import scala.util.{Failure, Success, Try}
+import scodec.bits.ByteVector
+
+object Transit extends Spec with ScalaCheck with TransitData {
+  override def is: SpecStructure =
+   s2"""
+     | encrypt works as expected when sending valid data $encryptSpec
+     | encrypt fails if the token is not recognised      $encryptForbiddenSpec
+     | decrypt works as expected when sending valid data $decryptSpec
+     | decrypt fails if the token is not recognised      $decryptForbiddenSpec
+     """.stripMargin
+
+  val encryptSpec: Prop = Prop.forAll(genTestCase){ testCase =>
+    import testCase.mockClient
+    val transit = new TransitClient[IO](mockClient, Uri.uri("http://vault.test.com"), token, KeyName(keyName))
+    val plainText = PlainText(Order.toBase64(testCase.order))
+    val context   = Context(Agent.toBase64(testCase.agent))
+    val actual = transit.encryptInContext(plainText, context)
+    actual.unsafeRunSync.value === testCase.encrypted
+  }
+
+  val encryptForbiddenSpec: Prop = Prop.forAll(genTestCase){ testCase =>
+    import testCase.mockClient
+    val otoken = token + "X"
+    val transit = new TransitClient[IO](mockClient, Uri.uri("http://vault.test.com"), otoken, KeyName(keyName))
+    val plainText = PlainText(Order.toBase64(testCase.order))
+    val context   = Context(Agent.toBase64(testCase.agent))
+    val actual = transit.encryptInContext(plainText, context)
+    actual.attempt.unsafeRunSync.isLeft
+  }
+
+  val decryptSpec: Prop = Prop.forAll(genTestCase){ testCase =>
+    import testCase.mockClient
+    val transit = new TransitClient[IO](mockClient, Uri.uri("http://vault.test.com"), token, KeyName(keyName))
+    val context   = Context(Agent.toBase64(testCase.agent))
+    val actual = transit.decryptInContext(testCase.encrypted, context)
+      .map(pt => Order.fromBase64(pt.plaintext) )
+    actual.unsafeRunSync === Right(testCase.order)
+  }
+
+  val decryptForbiddenSpec: Prop = Prop.forAll(genTestCase){ testCase =>
+    import testCase.mockClient
+    val otoken = token + "X"
+        val transit = new TransitClient[IO](mockClient, Uri.uri("http://vault.test.com"), otoken, KeyName(keyName))
+    val context   = Context(Agent.toBase64(testCase.agent))
+    val actual = transit.decryptInContext(testCase.encrypted, context)
+    actual.attempt.unsafeRunSync.isLeft
+  }
+}
+
+trait TransitData {
+
+  val keyName = "testingKey"
+  val token = "vaultToken"
+
+  case class TestCase(order: Order, agent: Agent, encrypted: CipherText) {
+    def mockClient: Client[IO] = Client.fromHttpApp {
+      val context = Agent.toBase64(agent)
+      val plain = Order.toBase64(order)
+      new MockTransitService[IO](keyName, "vaultToken", Some(Context(context)), encrypted, PlainText(plain)).routes
+    }
+  }
+
+  // As as hypothetical example of Base64 encoding/decoding, which we use to test complex case
+  case class Order(company: String, numShares: Int, price: Int)
+  object Order {
+    private val Pattern = "([a-zA-Z]+),([0-9]+),([0-9]+);".r
+
+    def toBase64(a: Order): Base64 =
+        stringBase64.toBase64(s"${a.company},${a.numShares},${a.price};")
+
+    def fromBase64(bv: Base64): Either[String, Order] =
+      stringBase64.fromBase64(bv).flatMap {
+        case Pattern(co, nu, pri) => Right(Order(co, nu.toInt, pri.toInt))
+        case str => Left(s"$str is not a valid order coder")
+      }
+
+    implicit val eqOrder: Eq[Order] = Eq.fromUniversalEquals
+  }
+
+  case class Agent(license: UUID)
+  object Agent {
+    def toBase64(a: Agent): Base64 =
+      stringBase64.toBase64(a.license.toString)
+
+    def fromBase64(bv: Base64): Either[String,Agent] =
+      stringBase64.fromBase64(bv).flatMap { str =>
+        Try(UUID.fromString(str)) match {
+          case Success(value) => Right(Agent(value))
+          case Failure(tr) => Left( tr.getMessage()) 
+        }
+      }
+  }
+
+  val genOrder: Gen[Order] = for {
+    company <- Gen.alphaStr.filterNot(_.isEmpty())
+    numShares <- Gen.choose[Int](100, 1000)
+    price <- Gen.choose(1, 10000)
+   } yield Order(company, numShares, price)
+
+  val genAgent = Gen.uuid.map(Agent(_))
+
+  val genTestCase = for {
+    encrypted <- TransitGenerators.cipherText
+    order <- genOrder
+    agent <- genAgent
+  } yield TestCase(order, agent, encrypted)
+
+
+  object stringBase64 {
+    def toBase64(s: String): Base64 =
+      Base64.fromByteVector(ByteVector.view(s.getBytes("UTF-8")))
+    def fromBase64(b64: Base64): Either[String, String] =
+      ByteVector.fromBase64Descriptive(b64.value).map(bv => new String(bv.toArray, "UTF-8"))
+  }
+
+}


### PR DESCRIPTION
Continues from #51.

[Vault Transit](https://www.vaultproject.io/docs/secrets/transit/index.html) is a secrets engine that provides "encryption as a service": it allows creating (on the server) encryption keys with a specific algorithm, and offers an HTTP API with endpoints to encrypt or decrypt data, relieving client from the need to handle keys (which is risky) or implement cryptosystems (which is error-prone). 

In this Pull Request, we add support for transit endpoints. In particular:

- We add a transit-client class, made of a HTTP Client, a key name, and the vault base URI. The ideal use of this Transit-Client is as a representation of a transit connection, which hides all of the transit logic and only provides encryption/decryption functions.
- In line with the design of the Vault client, we also add a Transit object that provides the main functions separately.
- We add a set of models, to represent the requests and responses of the Vault-transit endpoints, and their Json encoding and decoding.
- We add a small wrapper type for Base64-Encoded strings, since that is what Vault-Transit uses for contexts and plaintext values.
  In this library we will not deal with encoding/decoding of other values into Base64: we refer to `scodec` library for that.
- We add some wrapper-clases for contexts and plaintexts, to tell them apart in the type level. We also add a wrapper class for the Ciphertext, but on this one we make no assumptions about the inner string.

In this library we will not deal with encoding/decoding of other data types into Base64. Doing that was considered at first, but there were some reasons not to do so:

- This library is a Scala representation of Vault api, so there is no need to do strictly more than a Vault client would do.
- Other libraries like [`scodec`](https://github.com/scodec/scodec) already define such type-class with a rich set of instances, so no point in inventing a training wheel.