### PR TITLE
Transit: Batch encrypt and decrypt

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/Transit.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Transit.scala
@@ -114,7 +114,7 @@ object Transit {
     (client: Client[F], vaultUri: Uri, token: String, key: KeyName)
     (inputs: List[(CipherText, Context)])
       : F[List[TransitError.Or[PlainText]]] =
-    new TransitClient[F](client, vaultUri, token, key).decryptBatchInContext(inputs)
+    new TransitClient[F](client, vaultUri, token, key).decryptInContextBatch(inputs)
 
 }
 
@@ -269,7 +269,7 @@ final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String,
     *
     *  https://www.vaultproject.io/api/secret/transit/index.html#batch_input-2
     */
-  def decryptBatchInContext(inputs: List[(CipherText, Context)]): F[List[TransitError.Or[PlainText]]] = {
+  def decryptInContextBatch(inputs: List[(CipherText, Context)]): F[List[TransitError.Or[PlainText]]] = {
     val payload = DecryptBatchRequest(inputs.map { case (cipht, ctx) => DecryptRequest(cipht, Some(ctx)) } )
     val request = doRequest(decryptUri, payload)
     for {

--- a/core/src/main/scala/com/banno/vault/transit/models.scala
+++ b/core/src/main/scala/com/banno/vault/transit/models.scala
@@ -17,8 +17,7 @@
 package com.banno.vault.transit
 
 import cats.Eq
-import cats.kernel.instances.option._
-import cats.kernel.instances.string._
+import cats.kernel.instances.all._
 import cats.syntax.eq._
 import io.circe.{Decoder, Encoder, Json}
 import java.time.Instant
@@ -145,6 +144,26 @@ private[transit] object EncryptResponse {
     Decoder.forProduct1("data")((d: EncryptResult) => EncryptResponse(d))
 }
 
+private[transit] final case class EncryptBatchRequest(batchInput: List[EncryptRequest])
+private[transit] object EncryptBatchRequest {
+  implicit val eqEncryptBatchRequest: Eq[EncryptBatchRequest] =
+    Eq.by[EncryptBatchRequest, List[EncryptRequest]](_.batchInput)
+  implicit val encodeEncryptBatchRequest: Encoder[EncryptBatchRequest] =
+    Encoder.forProduct1("batch_input")(_.batchInput)
+  implicit val decodeEncryptBatchRequest: Decoder[EncryptBatchRequest] =
+    Decoder.forProduct1("batch_input")((bi: List[EncryptRequest]) => EncryptBatchRequest(bi))
+}
+
+private[transit] final case class EncryptBatchResponse(batchResults: List[TransitError.Or[EncryptResult]])
+private[transit] object EncryptBatchResponse {
+  implicit val eqEncryptBatchResponse: Eq[EncryptBatchResponse] =
+    Eq.by(_.batchResults)
+  implicit val encodeEncryptBatchResponse: Encoder[EncryptBatchResponse] =
+    Encoder.forProduct1("batch_results")(_.batchResults)
+  implicit val decodeEncryptBatchResponse: Decoder[EncryptBatchResponse] =
+    Decoder.forProduct1("batch_results")((br: List[TransitError.Or[EncryptResult]]) => EncryptBatchResponse(br))
+}
+
 private[transit] final case class DecryptRequest(ciphertext: CipherText, context: Option[Context])
 private[transit] object DecryptRequest {
   implicit val eqDecryptRequest: Eq[DecryptRequest] =
@@ -186,6 +205,8 @@ private[transit] final case class TransitError(error: String)
 private[transit] object TransitError {
   type Or[A] = Either[TransitError, A]
 
+  implicit val eqError: Eq[TransitError] = Eq.by(_.error)
+
   implicit val encodeError: Encoder[TransitError] =
     Encoder.forProduct1("error")(_.error)
 
@@ -201,4 +222,24 @@ private[transit] object TransitError {
   implicit def decodeOr[A](implicit decodeA: Decoder[A]): Decoder[Or[A]] =
     decodeError either decodeA
 
+}
+
+private[transit] final case class DecryptBatchRequest(batchInput: List[DecryptRequest])
+private[transit] object DecryptBatchRequest {
+  implicit val eqDecryptBatchRequest: Eq[DecryptBatchRequest] =
+    Eq.by[DecryptBatchRequest, List[DecryptRequest]](_.batchInput)
+  implicit val encodeDecryptBatchRequest: Encoder[DecryptBatchRequest] =
+    Encoder.forProduct1("batch_input")(_.batchInput)
+  implicit val decodeDecryptBatchRequest: Decoder[DecryptBatchRequest] =
+    Decoder.forProduct1("batch_input")((bi: List[DecryptRequest]) => DecryptBatchRequest(bi))
+  
+}
+private[transit] final case class DecryptBatchResponse(batchResults: List[TransitError.Or[DecryptResult]])
+private[transit] object DecryptBatchResponse {
+  implicit val eqDecryptBatchResponse: Eq[DecryptBatchResponse] =
+    Eq.by[DecryptBatchResponse, List[TransitError.Or[DecryptResult]]](_.batchResults)
+  implicit val encodeDecryptBatchResponse: Encoder[DecryptBatchResponse] =
+    Encoder.forProduct1("batch_results")(_.batchResults)
+  implicit val decodeDecryptBatchResponse: Decoder[DecryptBatchResponse] =
+    Decoder.forProduct1("batch_results")((br: List[TransitError.Or[DecryptResult]]) => DecryptBatchResponse(br))
 }

--- a/core/src/test/scala/com/banno/vault/transit/MockTransitService.scala
+++ b/core/src/test/scala/com/banno/vault/transit/MockTransitService.scala
@@ -91,7 +91,7 @@ final class MockTransitService[F[_]: Sync](
           case Some(bc) => decryptResult(bc.plaintext)
         }
       }
-      Ok(Json.obj("batch_results" -> Json.arr(results: _*)))
+      Ok(Json.obj("batch_results" -> Json.fromValues(results)))
     }
 
   private def encryptBatch(req: Request[F]): EitherT[F, DecodeFailure, Response[F]] = 
@@ -102,7 +102,7 @@ final class MockTransitService[F[_]: Sync](
           case Some(bc) => encryptResult(bc.ciphertext)
         }
       }
-      Ok(Json.obj("batch_results" -> Json.arr(results: _*)))
+      Ok(Json.obj("batch_results" -> Json.fromValues(results)))
     }
 }
 

--- a/core/src/test/scala/com/banno/vault/transit/ModelsSpec.scala
+++ b/core/src/test/scala/com/banno/vault/transit/ModelsSpec.scala
@@ -86,7 +86,7 @@ object TransitModelsSpec extends Spec with ScalaCheck {
 
   val encodeEncryptBatchRequestProp: Prop = Prop.forAll(genEncryptBatchRequest){ (ebr: EncryptBatchRequest) => 
     ebr.asJson === Json.obj( "batch_input" -> 
-      Json.arr( ebr.batchInput.map { 
+      Json.fromValues( ebr.batchInput.map { 
         case EncryptRequest(PlainText(pt), None) => 
           Json.obj(
             "plaintext" -> Json.fromString(pt.value)
@@ -96,20 +96,20 @@ object TransitModelsSpec extends Spec with ScalaCheck {
             "plaintext" -> Json.fromString(pt.value),
             "context" -> Json.fromString(ctx.value)
           )
-      }: _*)
+      })
     )
   }
 
   val encodeEncryptBatchResponseProp: Prop = Prop.forAll(Gen.listOf(cipherText)){ cts =>
-    val json = Json.obj("batch_response" -> Json.arr(
-      cts.map((ct: CipherText) => Json.obj("ciphertext" -> Json.fromString(ct.ciphertext))): _*
+    val json = Json.obj("batch_response" -> Json.fromValues(
+      cts.map((ct: CipherText) => Json.obj("ciphertext" -> Json.fromString(ct.ciphertext)))
     ))
     EncryptBatchResponse(cts.map((ct: CipherText) => Right(EncryptResult(ct)))).asJson === json
   }
 
   val decodeDecryptBatchResponseProp: Prop = Prop.forAll(Gen.listOf(base64)){ (plaintexts: List[Base64]) =>
-    val json = Json.obj( "batch_response" -> Json.arr(
-      plaintexts.map( pt => DecryptResult(PlainText(pt)).asJson): _*
+    val json = Json.obj( "batch_response" -> Json.fromValues(
+      plaintexts.map( pt => DecryptResult(PlainText(pt)).asJson)
     ))
     val expected = DecryptBatchResponse(plaintexts.map( (pt: Base64) => Right(DecryptResult(PlainText(pt)))))
     DecryptBatchResponse.decodeDecryptBatchResponse.decodeJson(json) === Right(expected)

--- a/core/src/test/scala/com/banno/vault/transit/TransitGenerators.scala
+++ b/core/src/test/scala/com/banno/vault/transit/TransitGenerators.scala
@@ -32,7 +32,36 @@ object TransitGenerators extends VaultArbitraries {
 
   val base64: Gen[Base64] = byteVector.map(Base64.fromByteVector)
 
-  // we generate examples like we have seen so far: a base64-encoded literal, prefixed by `vault:v1:` 
+  // we generate examples like we have seen so far: a base64-encoded literal, prefixed by `vault:v1:`
   val cipherText: Gen[CipherText] = base64.map( x => CipherText(s"vault:v1:${x.value}"))
+  val plaintext: Gen[PlainText] = base64.map( (p: Base64) => PlainText(p))
+  val context: Gen[Context] = base64.map( (p: Base64) => Context(p))
+
+  val transitError: Gen[TransitError] = Gen.alphaNumStr.map( (s: String) => TransitError(s))
+
+  val genEncryptRequest: Gen[EncryptRequest] =
+    for { pt <- plaintext ; ctx <- context } yield EncryptRequest(pt, Some(ctx))
+
+  val encryptResult: Gen[EncryptResult] = 
+    cipherText.map((p: CipherText) => EncryptResult(p))
+
+  val genEncryptBatchRequest: Gen[EncryptBatchRequest] =
+    Gen.listOf(genEncryptRequest).map(ps => EncryptBatchRequest(ps))
+ 
+  val genAllRightEncryptBatchResponse: Gen[EncryptBatchResponse] =
+    Gen.listOf(right[TransitError, EncryptResult](encryptResult))
+      .map( (rps: List[TransitError.Or[EncryptResult]]) => EncryptBatchResponse(rps))
+
+  val genEncryptBatchResponse: Gen[EncryptBatchResponse] =
+    Gen.listOf(errorOr(encryptResult))
+      .map((rps: List[TransitError.Or[EncryptResult]]) => EncryptBatchResponse(rps))
+
+  def some[A](genA: Gen[A]): Gen[Option[A]] = genA.map( (a:A) => Some(a) )
+  def right[A, B](genB: Gen[B]): Gen[Either[A, B]] = genB.map(b => Right(b))
+
+  def errorOr[A](genA: Gen[A]): Gen[TransitError.Or[A]] = either(transitError, genA)
+
+  def either[T, U](gt: Gen[T], gu: Gen[U]): Gen[Either[T, U]] =
+    Gen.oneOf(gt.map(Left(_)), gu.map(Right(_)))
 
 }


### PR DESCRIPTION
Vault Transit endpoints to encrypt and decrypt data allow for a batch-input mode, in which multiple plaintexts (accompanied or not by a context) may be given in a single go and decrypted, using a single
round-trip for the operation.

This Pull Request adds support in the `transit` package for batched decrypt and encrypt operations. Unlike the single-input variants, that either succeed or fail, a batched request may succeed for some inputs but fail for others. Thus, we need to expose the TransitError case class outside.

We also extend the documentation of the other functions, and we add into the error some context for the operation that failed.