### PR TITLE
Build: add MIMA exclusions to by-pass known bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,26 @@ lazy val `vault4s` = project.in(file("."))
 lazy val core = project.in(file("core"))
   .settings(commonSettings)
   .settings(
-    name := "vault4s"
+    name := "vault4s",
+    mimaBinaryIssueFilters ++= {
+      import com.typesafe.tools.mima.core.IncompatibleSignatureProblem
+      import com.typesafe.tools.mima.core.ProblemFilters.exclude
+      // See https://github.com/lightbend/mima/issues/423
+      Seq(
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.Base64.decodeBase64"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.Base64.encodeBase64"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.Base64.eqBase64"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.Base64.fromStringOpt"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.CipherText.decodeCipherText"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.CipherText.encodeCipherText"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.CipherText.eqCipherText"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.Context.unapply"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.DecryptRequest.unapply"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.EncryptResult.unapply"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.EncryptResult.unapply"),
+        exclude[IncompatibleSignatureProblem]("com.banno.vault.transit.PlainText.unapply")
+      )
+    },
   )
 
 lazy val docs = project.in(file("docs"))


### PR DESCRIPTION
The build for the versions 5.2.0 has been failing because of a bug in MIMA, described  in https://github.com/lightbend/mima/issues/432.
To avoid falling into that bug, we add exclusion filters.