### PR TITLE
Open visibility of the TransitError class.

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/models.scala
+++ b/core/src/main/scala/com/banno/vault/transit/models.scala
@@ -201,7 +201,7 @@ private[transit] object DecryptResponse {
     Decoder.forProduct1("data")((d: DecryptResult) => DecryptResponse(d))
 }
 
-private[transit] final case class TransitError(error: String)
+final case class TransitError(error: String)
 private[transit] object TransitError {
   type Or[A] = Either[TransitError, A]
 


### PR DESCRIPTION
Since this case class is exposed outside in API, we need
to make it visible to the users and not package-private.