### PR TITLE
Transit Batch endpoints: short-cut on empty list of inputs.

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/Transit.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Transit.scala
@@ -187,19 +187,21 @@ final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String,
     *
     * https://www.vaultproject.io/api/secret/transit/index.html#batch_input
     */
-  def encryptBatch(plaintexts: List[PlainText]): F[List[TransitError.Or[CipherText]]] = {
-    val payload = EncryptBatchRequest(plaintexts.map(EncryptRequest(_, None)))
-    encryptBatchAux(payload, "EncryptBatch without context")
-  }
+  def encryptBatch(plaintexts: List[PlainText]): F[List[TransitError.Or[CipherText]]] =
+    if (plaintexts.isEmpty) F.pure(Nil) else {
+      val payload = EncryptBatchRequest(plaintexts.map(EncryptRequest(_, None)))
+      encryptBatchAux(payload, "EncryptBatch without context")
+    }
 
   /** Function to encrypt a batch of context-plaintext pairs in a single trip.
     *
     * https://www.vaultproject.io/api/secret/transit/index.html#batch_input
     */
-  def encryptInContextBatch(inputs: List[(PlainText, Context)]): F[List[TransitError.Or[CipherText]]] = {
-    val payload = EncryptBatchRequest(inputs.map { case (pt, ctx) => EncryptRequest(pt, Some(ctx)) })
-    encryptBatchAux(payload, "EncryptBatch with context")
-  }
+  def encryptInContextBatch(inputs: List[(PlainText, Context)]): F[List[TransitError.Or[CipherText]]] =
+    if (inputs.isEmpty) F.pure(Nil) else {
+      val payload = EncryptBatchRequest(inputs.map { case (pt, ctx) => EncryptRequest(pt, Some(ctx)) })
+      encryptBatchAux(payload, "EncryptBatch with context")
+    }
 
   private def encryptBatchAux(payload: EncryptBatchRequest, op: String): F[List[TransitError.Or[CipherText]]] = {
     val request = postOf(encryptUri, payload)
@@ -245,10 +247,11 @@ final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String,
     *
     * https://www.vaultproject.io/api/secret/transit/index.html#batch_input-2
     */
-  def decryptBatch(inputs: List[CipherText]): F[List[TransitError.Or[PlainText]]] = {
-    val payload = DecryptBatchRequest(inputs.map((cipht: CipherText) => DecryptRequest(cipht, None)))
-    decryptBatchAux(payload, "DecryptBatch without context")
-  }
+  def decryptBatch(inputs: List[CipherText]): F[List[TransitError.Or[PlainText]]] =
+    if (inputs.isEmpty) F.pure(Nil) else {
+      val payload = DecryptBatchRequest(inputs.map((cipht: CipherText) => DecryptRequest(cipht, None)))
+      decryptBatchAux(payload, "DecryptBatch without context")
+    }
 
   /** Decrypts a batch of input pairs (ciphertexts and contexts) using a single round-trip to the Vault server.
     * Returns a list where each entry is the attempted result of decrypting the input at the same position.
@@ -256,9 +259,10 @@ final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String,
     *
     *  https://www.vaultproject.io/api/secret/transit/index.html#batch_input-2
     */
-  def decryptInContextBatch(inputs: List[(CipherText, Context)]): F[List[TransitError.Or[PlainText]]] = {
-    val payload = DecryptBatchRequest(inputs.map { case (cipht, ctx) => DecryptRequest(cipht, Some(ctx)) } )
-    decryptBatchAux(payload, "DecryptBatch with context")
+  def decryptInContextBatch(inputs: List[(CipherText, Context)]): F[List[TransitError.Or[PlainText]]] =
+    if (inputs.isEmpty) F.pure(Nil) else {
+      val payload = DecryptBatchRequest(inputs.map { case (cipht, ctx) => DecryptRequest(cipht, Some(ctx)) } )
+      decryptBatchAux(payload, "DecryptBatch with context")
   }
 
   private def decryptBatchAux(payload: DecryptBatchRequest, op: String): F[List[TransitError.Or[PlainText]]] = {

--- a/core/src/main/scala/com/banno/vault/transit/models.scala
+++ b/core/src/main/scala/com/banno/vault/transit/models.scala
@@ -17,6 +17,7 @@
 package com.banno.vault.transit
 
 import cats.Eq
+import cats.data.NonEmptyList
 import cats.kernel.instances.all._
 import cats.syntax.eq._
 import io.circe.{Decoder, Encoder, Json}
@@ -144,24 +145,24 @@ private[transit] object EncryptResponse {
     Decoder.forProduct1("data")((d: EncryptResult) => EncryptResponse(d))
 }
 
-private[transit] final case class EncryptBatchRequest(batchInput: List[EncryptRequest])
+private[transit] final case class EncryptBatchRequest(batchInput: NonEmptyList[EncryptRequest])
 private[transit] object EncryptBatchRequest {
   implicit val eqEncryptBatchRequest: Eq[EncryptBatchRequest] =
-    Eq.by[EncryptBatchRequest, List[EncryptRequest]](_.batchInput)
+    Eq.by[EncryptBatchRequest, NonEmptyList[EncryptRequest]](_.batchInput)
   implicit val encodeEncryptBatchRequest: Encoder[EncryptBatchRequest] =
     Encoder.forProduct1("batch_input")(_.batchInput)
   implicit val decodeEncryptBatchRequest: Decoder[EncryptBatchRequest] =
-    Decoder.forProduct1("batch_input")((bi: List[EncryptRequest]) => EncryptBatchRequest(bi))
+    Decoder.forProduct1("batch_input")((bi: NonEmptyList[EncryptRequest]) => EncryptBatchRequest(bi))
 }
 
-private[transit] final case class EncryptBatchResponse(batchResults: List[TransitError.Or[EncryptResult]])
+private[transit] final case class EncryptBatchResponse(batchResults: NonEmptyList[TransitError.Or[EncryptResult]])
 private[transit] object EncryptBatchResponse {
   implicit val eqEncryptBatchResponse: Eq[EncryptBatchResponse] =
     Eq.by(_.batchResults)
   implicit val encodeEncryptBatchResponse: Encoder[EncryptBatchResponse] =
     Encoder.forProduct1("batch_results")(_.batchResults)
   implicit val decodeEncryptBatchResponse: Decoder[EncryptBatchResponse] =
-    Decoder.forProduct1("batch_results")((br: List[TransitError.Or[EncryptResult]]) => EncryptBatchResponse(br))
+    Decoder.forProduct1("batch_results")((br: NonEmptyList[TransitError.Or[EncryptResult]]) => EncryptBatchResponse(br))
 }
 
 private[transit] final case class DecryptRequest(ciphertext: CipherText, context: Option[Context])
@@ -224,22 +225,22 @@ private[transit] object TransitError {
 
 }
 
-private[transit] final case class DecryptBatchRequest(batchInput: List[DecryptRequest])
+private[transit] final case class DecryptBatchRequest(batchInput: NonEmptyList[DecryptRequest])
 private[transit] object DecryptBatchRequest {
   implicit val eqDecryptBatchRequest: Eq[DecryptBatchRequest] =
-    Eq.by[DecryptBatchRequest, List[DecryptRequest]](_.batchInput)
+    Eq.by[DecryptBatchRequest, NonEmptyList[DecryptRequest]](_.batchInput)
   implicit val encodeDecryptBatchRequest: Encoder[DecryptBatchRequest] =
     Encoder.forProduct1("batch_input")(_.batchInput)
   implicit val decodeDecryptBatchRequest: Decoder[DecryptBatchRequest] =
-    Decoder.forProduct1("batch_input")((bi: List[DecryptRequest]) => DecryptBatchRequest(bi))
+    Decoder.forProduct1("batch_input")((bi: NonEmptyList[DecryptRequest]) => DecryptBatchRequest(bi))
   
 }
-private[transit] final case class DecryptBatchResponse(batchResults: List[TransitError.Or[DecryptResult]])
+private[transit] final case class DecryptBatchResponse(batchResults: NonEmptyList[TransitError.Or[DecryptResult]])
 private[transit] object DecryptBatchResponse {
   implicit val eqDecryptBatchResponse: Eq[DecryptBatchResponse] =
-    Eq.by[DecryptBatchResponse, List[TransitError.Or[DecryptResult]]](_.batchResults)
+    Eq.by[DecryptBatchResponse, NonEmptyList[TransitError.Or[DecryptResult]]](_.batchResults)
   implicit val encodeDecryptBatchResponse: Encoder[DecryptBatchResponse] =
     Encoder.forProduct1("batch_results")(_.batchResults)
   implicit val decodeDecryptBatchResponse: Decoder[DecryptBatchResponse] =
-    Decoder.forProduct1("batch_results")((br: List[TransitError.Or[DecryptResult]]) => DecryptBatchResponse(br))
+    Decoder.forProduct1("batch_results")((br: NonEmptyList[TransitError.Or[DecryptResult]]) => DecryptBatchResponse(br))
 }


### PR DESCRIPTION
At present, running with an empty list of inputs will produce a raise error (because there is no Right answer). To correct this, and for the optimisation of avoiding unneeded calls, we add a short-cut to end quick on an empty list of inputs.