### PR TITLE
Fix transit uris

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/Transit.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Transit.scala
@@ -94,9 +94,10 @@ final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String,
   /* The URIs we use here are those from the transit documentation.
    * the v1 prefix is specified in https://www.vaultproject.io/api/overview
    */
-  private val encryptUri: Uri =  vaultUri / "v1" / "transit" / "encrypt" / key.name
-  private val decryptUri: Uri =  vaultUri / "v1" / "transit" / "decrypt" / key.name
-  private val readKeyUri: Uri =  vaultUri / "v1" / "transit" / "keys"    / key.name
+
+  private val encryptUri: Uri = vaultUri.withPath(s"/v1/transit/encrypt/${key.name}")
+  private val decryptUri: Uri = vaultUri.withPath(s"/v1/transit/decrypt/${key.name}")
+  private val readKeyUri: Uri = vaultUri.withPath(s"/v1/transit/keys/${key.name}")
 
   private val tokenHeaders: Headers = Headers.of(Header("X-Vault-Token", token))
 


### PR DESCRIPTION
Don't uri encode the key in the transit endpoints.

This is consistent with how dynamic uris are created within `Vaults` ([example](https://github.com/Banno/vault4s/blob/605c76d28219ff301295c347e03a2f460dfe1f31/core/src/main/scala/com/banno/vault/Vault.scala#L78)).