### PR TITLE
Adjust decoder of DecryptResponse, to accept optional plaintext.

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/Base64.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Base64.scala
@@ -31,6 +31,8 @@ final class Base64 private[Base64] (val value: String) extends AnyVal {
 
 object Base64 {
 
+  val empty: Base64 = new Base64("")
+
   implicit val eqBase64: Eq[Base64] = Eq.by[Base64, String](_.value)
 
   implicit final val decodeBase64: Decoder[Base64] =


### PR DESCRIPTION
Due to https://github.com/hashicorp/vault/issues/6140, sometimes
we may get a response in which the plaintext is missing field,
which happens if it would have been an empty string.