### PR TITLE
Fix transit batch encryption response decoding

### DIFF
--- a/core/src/test/scala/com/banno/vault/transit/MockTransitService.scala
+++ b/core/src/test/scala/com/banno/vault/transit/MockTransitService.scala
@@ -100,7 +100,7 @@ final class MockTransitService[F[_]: Sync]
           case Some(bc) => encryptResult(bc.ciphertext)
         }
       }
-      Ok(Json.obj("batch_results" -> Json.fromValues(results.toList)))
+      Ok(Json.obj("data" -> Json.obj("batch_results" -> Json.fromValues(results.toList))))
     }
 }
 


### PR DESCRIPTION
We were trying to decode `{ "batch_results" : [] }` while the response is `{ "data": { "batch_results" : [] } }`. 