### PR TITLE
Fix: decode key details

### DIFF
--- a/core/src/main/scala/com/banno/vault/transit/models.scala
+++ b/core/src/main/scala/com/banno/vault/transit/models.scala
@@ -59,7 +59,7 @@ object KeyDetails {
       Decoder.instance[KeyDetails] { c =>
         Decoder.resultInstance.map5(
           c.downField("data").downField("name").as[String],
-          c.downField("data").downField("convergent_encryption").as[Boolean],
+          c.downField("data").downField("convergent_encryption").as[Option[Boolean]].map(_.getOrElse(false)),
           c.downField("data").downField("derived").as[Boolean],
           c.downField("data").downField("keys").as[Map[Int, Instant]],
           c.downField("data").downField("type").as[String]


### PR DESCRIPTION
When we built the decoder, we did it based on some experiments we run. 
Unfortunately, the Transit API docs do not specify all the fields we saw.
https://www.vaultproject.io/api-docs/secret/transit#read-key