### PR TITLE
Avoid echoing vault value on a decoding error

### DIFF
--- a/core/src/test/scala/com/banno/vault/VaultSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultSpec.scala
@@ -59,6 +59,7 @@ object VaultSpec extends Spec with ScalaCheck {
         |readSecret works as expected when requesting the private key with a valid token $readSecretPrivateKeyProp
         |readSecret works as expected when requesting the postgres password with an invalid token $readSecretPostgresBadTokenProp
         |readSecret works as expected when requesting the private key with an invalid token $readSecretPrivateKeyBadTokenProp
+        |readSecret suppresses echoing the data when JSON decoding fails $readSecretDecodingFailProp
         |renewToken works as expected when sending a valid token $renewAValidToken
         |revokeToken works as expected when revoking a valid token $revokeAValidToken
         |renewLease works as expected when sending valid input arguments $renewLeaseValidAddressProp
@@ -397,6 +398,16 @@ object VaultSpec extends Spec with ScalaCheck {
       .attempt
       .unsafeRunSync()
       .isLeft
+  }
+
+  val readSecretDecodingFailProp : Prop = Prop.forAll(VaultArbitraries.validVaultUri){uri =>
+    Vault.readSecret[IO, TokenValue](mockClient, uri)(clientToken, secretPrivateKeyPath)
+      .attempt
+      .unsafeRunSync()
+      .fold(
+        error => !error.getMessage.contains(privateKey),
+        Function.const(false)
+      )
   }
 
   val renewAValidToken : Prop = Prop.forAll(VaultArbitraries.validVaultUri){uri =>

--- a/core/src/test/scala/com/banno/vault/VaultSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultSpec.scala
@@ -405,8 +405,11 @@ object VaultSpec extends Spec with ScalaCheck {
       .attempt
       .unsafeRunSync()
       .fold(
-        error => !error.getMessage.contains(privateKey),
-        Function.const(false)
+        { error =>
+          if (error.getMessage.contains(privateKey)) Prop.falsified :| "Secret data in the error message"
+          else Prop.passed :| "Secret data redacted"
+        },
+        _ => Prop.falsified :| "Data should not be parseable"
       )
   }
 


### PR DESCRIPTION
The library currently will output the data from Vault if decoding fails, which will print out secret data, and will likely have it
written to logs. This should hide that value by changing the message of the resulting `InvalidMessageBodyFailure` error.