### PR TITLE
add list secret operation, which returns keys given a path

### DIFF
--- a/core/src/main/scala/com/banno/vault/Vault.scala
+++ b/core/src/main/scala/com/banno/vault/Vault.scala
@@ -20,7 +20,7 @@ import fs2.Stream
 import cats._
 import cats.effect._
 import cats.implicits._
-import com.banno.vault.models.{CertificateData, CertificateRequest, VaultRequestError, VaultSecret, VaultSecretRenewal, VaultToken}
+import com.banno.vault.models.{CertificateData, CertificateRequest, VaultRequestError, VaultSecret, VaultSecretRenewal, VaultToken, VaultKeys}
 import io.circe.{Decoder, DecodingFailure, Encoder, Json}
 import io.circe.syntax._
 import org.http4s._
@@ -84,6 +84,27 @@ object Vault {
     }.handleErrorWith { e =>
       F.raiseError(VaultRequestError(request = request, cause = e.some, extra = s"tokenLength=${token.length}".some))
     }
+  }
+
+  /**
+   *  https://www.vaultproject.io/api/secret/kv/kv-v1#list-secrets uses GET alternative https://www.vaultproject.io/api-docs#api-operations vs LIST
+   */
+  def listSecrets[F[_]](client: Client[F], vaultUri: Uri)(token: String, secretPath: String)(implicit F: Sync[F]): F[VaultKeys] = {
+    val newSecretPath = if (secretPath.startsWith("/")) secretPath.substring(1) else secretPath
+    val request = Request[F](
+        method = Method.GET,
+        uri = vaultUri.withPath(s"/v1/$newSecretPath").withQueryParam("list", "true"),
+        headers = Headers.of(Header("X-Vault-Token", token))
+      )
+    for {
+      result <- 
+        F.adaptError(client.expect[VaultKeys](request)(jsonOf[F, VaultKeys])) {
+          case InvalidMessageBodyFailure(_, Some(cause: DecodingFailure)) =>
+            InvalidMessageBodyFailure("Could not decode vault list secrets response", cause.some)
+        }.handleErrorWith { e =>
+          F.raiseError(VaultRequestError(request = request, cause = e.some, extra = s"tokenLength=${token.length}".some))
+        }
+    } yield result
   }
 
   /**

--- a/core/src/main/scala/com/banno/vault/models/VaultKeys.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultKeys.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.vault.models
+
+import io.circe.Decoder
+import cats.Eq
+import cats.implicits._
+
+final case class VaultKeys(keys: List[String])
+
+object VaultKeys {
+
+  implicit val vaultKeysDecoder: Decoder[VaultKeys] =
+    Decoder.instance[VaultKeys] { c =>
+      Decoder.resultInstance.map(
+        c.downField("data").get[List[String]]("keys")
+      )(VaultKeys.apply)
+    }
+
+  implicit val VaultKeysEq : Eq[VaultKeys] = Eq.instance[VaultKeys]((vt1, vt2) =>
+    vt1.keys === vt2.keys
+  )
+
+}

--- a/core/src/test/scala/com/banno/vault/VaultSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultSpec.scala
@@ -21,11 +21,12 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.{IO, Sync}
 import cats.implicits._
-import com.banno.vault.models.{CertificateData, CertificateRequest, VaultSecret, VaultSecretRenewal, VaultToken}
+import com.banno.vault.models.{CertificateData, CertificateRequest, VaultSecret, VaultSecretRenewal, VaultToken, VaultKeys}
 import io.circe.Decoder
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl.Http4sDsl
+import org.http4s.dsl.impl.QueryParamDecoderMatcher
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.circe._
 import org.http4s.client.Client
@@ -82,6 +83,8 @@ class VaultSpec extends ScalaCheckSuite {
 
   implicit val certificateRequestDecoder: Decoder[CertificateRequest] =
     Decoder.forProduct7("common_name", "alt_names", "ip_sans", "ttl", "format", "private_key_format", "exclude_cn_from_sans")(CertificateRequest.apply)
+
+  object ListQueryParamMatcher extends QueryParamDecoderMatcher[String]("list")
 
   val certificate: String      = UUID.randomUUID().toString
   val issuing_ca: String       = UUID.randomUUID().toString
@@ -270,6 +273,15 @@ class VaultSpec extends ScalaCheckSuite {
                   |}""".stripMargin)
           }
         }
+      case req @ GET -> Root / "v1" / "secret" / "postgres" / "" :? ListQueryParamMatcher(_) =>
+        checkVaultToken(req){
+          Ok(s"""
+                |{
+                | "data": {
+                |   "keys": ["postgres1", "postgres-pupper"]
+                | }
+                |}""".stripMargin)
+        }
 
       case GET -> path =>
         BadRequest(s"Path not mapped: $path")
@@ -406,6 +418,13 @@ property("readSecret suppresses echoing the data when JSON decoding fails") {
         },
         _ => Prop.falsified :| "Data should not be parseable"
       )
+  }
+}
+
+property("listSecrets works as expected when requesting keys under path") {
+  Prop.forAll(VaultArbitraries.validVaultUri){uri =>
+    Vault.listSecrets[IO](mockClient, uri)(clientToken, "/secret/postgres/")
+      .unsafeRunSync() == VaultKeys(List("postgres1", "postgres-pupper"))
   }
 }
 


### PR DESCRIPTION
For https://banno-jha.atlassian.net/browse/PUP-1525.

I opted to just use `GET` version with query param `list=true` vs using `LIST` http method.

https://www.vaultproject.io/api-docs#api-operations
https://www.vaultproject.io/api/secret/kv/kv-v1#list-secrets