### PR TITLE
seires/8.x Scala3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['*']
+    branches: ['*', series/*]
   push:
-    branches: ['*']
+    branches: ['*', series/*]
     tags: [v*]
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.3]
+        scala: [2.12.12, 2.13.3, 3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.3]
+        scala: [3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 val Scala213 = "2.13.3"
+val Scala3 = "3.0.0"
 
-ThisBuild / crossScalaVersions := Seq("2.12.12", Scala213)
+ThisBuild / crossScalaVersions := Seq("2.12.12", Scala213, Scala3)
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowArtifactUpload := false
@@ -60,9 +61,8 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 val http4sV = "0.22.0-RC1"
 val specs2V = "4.10.6"
-val munitCatsEffectV = "0.13.1"
-val munitScalaCheckV = "0.7.22"
-
+val munitCatsEffectV = "1.0.5"
+val munitScalaCheckV = "0.7.26"
 
 val kindProjectorV = "0.11.3"
 val betterMonadicForV = "0.3.1"
@@ -147,10 +147,7 @@ lazy val docs = project.in(file("docs"))
 // General Settings
 lazy val commonSettings = Seq(
   testFrameworks += new TestFramework("munit.Framework"),
-
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorV cross CrossVersion.full),
-  addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
-  libraryDependencies ++= Seq(
+  libraryDependencies ++= List(
     "org.http4s"                  %% "http4s-client"              % http4sV,
     "org.http4s"                  %% "http4s-circe"               % http4sV,
 
@@ -158,7 +155,14 @@ lazy val commonSettings = Seq(
     "org.typelevel"               %% "munit-cats-effect-2"        % munitCatsEffectV      % Test,
     "org.scalameta"               %% "munit-scalacheck"           % munitScalaCheckV      % Test
 
-  )
+  ) ++ {
+    if(scalaVersion.value.startsWith("3")) List.empty
+    else List(
+      compilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorV cross CrossVersion.full),
+      //"-source:future") could bring in support for better-monadic-for changes, but also breaks other things
+      compilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV)
+    )
+  }
 )
 
 lazy val contributors = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ ThisBuild / githubWorkflowBuild := Seq(
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 
+ThisBuild / githubWorkflowTargetBranches :=
+  Seq("*", "series/*")
+
 // currently only publishing tags
 ThisBuild / githubWorkflowPublishTargetBranches :=
   Seq(RefPredicate.StartsWith(Ref.Tag("v")))

--- a/core/src/main/scala/com/banno/vault/Vault.scala
+++ b/core/src/main/scala/com/banno/vault/Vault.scala
@@ -76,7 +76,7 @@ object Vault {
     val newSecretPath = if (secretPath.startsWith("/")) secretPath.substring(1) else secretPath
     val request = Request[F](
       method = Method.GET,
-      uri = vaultUri.withPath(Uri.Path.fromString(s"/v1/$newSecretPath")),
+      uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/$newSecretPath")),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
     )
     F.adaptError(client.expect[VaultSecret[A]](request)(jsonOf[F, VaultSecret[A]])) {
@@ -93,7 +93,7 @@ object Vault {
   def renewLease[F[_]](client: Client[F], vaultUri: Uri)(leaseId: String, newLeaseDuration: FiniteDuration, token: String)(implicit F: Sync[F]): F[VaultSecretRenewal] = {
     val request = Request[F](
         method = Method.PUT,
-        uri = vaultUri.withPath(Uri.Path.fromString("/v1/sys/leases/renew")),
+        uri = vaultUri.withPath(Uri.Path.unsafeFromString("/v1/sys/leases/renew")),
         headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
       ).withEntity(
         Json.obj(
@@ -150,7 +150,7 @@ object Vault {
   def revokeLease[F[_]](client: Client[F], vaultUri: Uri)(clientToken: String, leaseId: String)(implicit F: Sync[F]): F[Unit] = {
     val request = Request[F](
         method = Method.PUT,
-        uri = vaultUri.withPath(Uri.Path.fromString("/v1/sys/leases/revoke")),
+        uri = vaultUri.withPath(Uri.Path.unsafeFromString("/v1/sys/leases/revoke")),
         headers = Headers(Header.Raw(CIString("X-Vault-Token"), clientToken))
       ).withEntity( Json.obj( "lease_id" -> Json.fromString(leaseId) ) )
     for {
@@ -172,7 +172,7 @@ object Vault {
     val newSecretPath = if (secretPath.startsWith("/")) secretPath.substring(1) else secretPath
     val request =  Request[F](
       method = Method.POST,
-      uri = vaultUri.withPath(Uri.Path.fromString(s"/v1/$newSecretPath")),
+      uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/$newSecretPath")),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
     )
     val withBody = request.withEntity(payload.asJson)

--- a/core/src/main/scala/com/banno/vault/transit/Transit.scala
+++ b/core/src/main/scala/com/banno/vault/transit/Transit.scala
@@ -138,9 +138,9 @@ final class TransitClient[F[_]](client: Client[F], vaultUri: Uri, token: String,
    */
   private val keyAsPath: String = key.name.dropWhile(_ === '/')
 
-  private val encryptUri: Uri = vaultUri.withPath(Uri.Path.fromString(s"/v1/transit/encrypt/${keyAsPath}"))
-  private val decryptUri: Uri = vaultUri.withPath(Uri.Path.fromString(s"/v1/transit/decrypt/${keyAsPath}"))
-  private val readKeyUri: Uri = vaultUri.withPath(Uri.Path.fromString(s"/v1/transit/keys/${keyAsPath}"))
+  private val encryptUri: Uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/transit/encrypt/${keyAsPath}"))
+  private val decryptUri: Uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/transit/decrypt/${keyAsPath}"))
+  private val readKeyUri: Uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/transit/keys/${keyAsPath}"))
 
   private val tokenHeaders: Headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
 

--- a/core/src/main/scala/com/banno/vault/transit/models.scala
+++ b/core/src/main/scala/com/banno/vault/transit/models.scala
@@ -49,7 +49,7 @@ object KeyDetails {
       )
     )}
 
-    implicit final val decodeKeyDetails: Decoder[KeyDetails] = {
+  implicit final val decodeKeyDetails: Decoder[KeyDetails] = {
       implicit val decodeInstantSecond: Decoder[Instant] =
         Decoder.decodeLong.emap { numsec =>
           if (numsec <= Instant.MAX.getEpochSecond)

--- a/core/src/test/scala/com/banno/vault/VaultArbitraries.scala
+++ b/core/src/test/scala/com/banno/vault/VaultArbitraries.scala
@@ -2,14 +2,15 @@ package com.banno.vault
 
 import com.banno.vault.models.CertificateRequest
 import org.http4s.{Uri => Http4sUri}
+import org.http4s.implicits._
 import org.scalacheck.Gen
 import org.scalacheck.Gen._
 
 trait VaultArbitraries {
 
   val validVaultUri: Gen[Http4sUri] = Gen.oneOf(
-    Http4sUri.uri("http://localhost:8080"),
-    Http4sUri.uri("http://127.0.0.1:8080")
+    uri"http://localhost:8080",
+    uri"http://127.0.0.1:8080"
   )
 
   val invalidSecretPath: Gen[String] =

--- a/core/src/test/scala/com/banno/vault/transit/TransitSpec.scala
+++ b/core/src/test/scala/com/banno/vault/transit/TransitSpec.scala
@@ -22,6 +22,7 @@ import cats.implicits._
 import cats.kernel.Eq
 import java.util.UUID
 import org.http4s.Uri
+import org.http4s.implicits._
 import org.http4s.client.Client
 import org.scalacheck.{Gen, Prop}
 import org.scalacheck.Prop._
@@ -164,5 +165,5 @@ trait TransitData {
       ByteVector.fromBase64Descriptive(b64.value).map(bv => new String(bv.toArray, "UTF-8"))
   }
 
-  val testUri: Uri =  Uri.uri("http://vault.test.com")
+  val testUri: Uri =  uri"http://vault.test.com"
 }


### PR DESCRIPTION
- Fixed formatting where needed for Scala3
- Changed use of http4s uri for scala3
- Made type of implicits explicit.
- Changed any deprecation's to match whats in main.
- updated munit for scala 3

Also fixed #163 

See also #214 for update in main.