### PR TITLE
Rework commonSettings crossScalaVersion override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.6]
+        scala: [2.12.14, 2.13.6]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -142,8 +142,6 @@ lazy val docs = project.in(file("docs"))
 
 // General Settings
 lazy val commonSettings = Seq(
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.14"),
-
   addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala213 = "2.13.6"
 
-ThisBuild / crossScalaVersions := Seq("2.12.12", Scala213)
+ThisBuild / crossScalaVersions := Seq("2.12.14", Scala213)
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowArtifactUpload := false


### PR DESCRIPTION
In Series/8.x we found that the way this is setup we'll hit a case where we end up skipping over 2.13 because of how things are defined.  This enforces usage of ThisBuild.  
```
scalaVersion depends on crossScalaVersions, and then crossScalaVersions is later reset from scalaVersion.
10:21
And we’ve already introduced one mistake: 2.12.12 vs. 2.12.14.  But those generate binary compatible artifacts so nobody really notices.
10:21
And only by virtue of Scala213 being last does a 2.13 remain in the cross builds, so the landmine goes untriggered.
10:22
And now in series/8.x, we append a Scala3 to the end.  Now scalaVersion is 3.0.0.  But we’ve still got that weird redefinition.
10:22
And :boom: We’ve lost Scala 2.13.```