### PR TITLE
Merging forward from 6.x into 7.x (crossscalaversion fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.6]
+        scala: [2.12.14, 2.13.6]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala213 = "2.13.6"
 
-ThisBuild / crossScalaVersions := Seq("2.12.12", Scala213)
+ThisBuild / crossScalaVersions := Seq("2.12.14", Scala213)
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowArtifactUpload := false
@@ -144,7 +144,6 @@ lazy val docs = project.in(file("docs"))
 // General Settings
 lazy val commonSettings = Seq(
   testFrameworks += new TestFramework("munit.Framework"),
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.14"),
 
   addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),


### PR DESCRIPTION
The same fix as https://github.com/Banno/vault4s/pull/218 just moved forward from 6.x to 7.x.  