### PR TITLE
Downgrade to http4s-0.23.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 
 
-val http4sV = "1.0.0-M23"
+val http4sV = "0.23.0-RC1"
 val munitCatsEffectV = "1.0.5"
 val munitScalaCheckV = "0.7.26"
 


### PR DESCRIPTION
http4s-0.23 got skipped.  vault4s-9.x should use http4s-0.23.
