### PR TITLE
Experimental: Higher level VaultClient

### DIFF
--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -32,9 +32,10 @@ object VaultClient {
     } yield impl(client, vaultUri, token)
   }
 
-  private def impl[F[_]: Concurrent](client: Client[F], vaultUri: Uri, token: VaultToken): VaultClient[F] =
+  private def impl[F[_]: Concurrent](client: Client[F], vaultUri: Uri, tokenRef: Ref[F, VaultToken]): VaultClient[F] =
     new VaultClient[F] {
       def readSecret[A: Decoder](secretPath: String): F[VaultSecret[A]] =
-        Vault.readSecret(client, vaultUri)(token.clientToken, secretPath)
+        tokenRef.get.flatMap(token =>
+          Vault.readSecret(client, vaultUri)(token.clientToken, secretPath))
     }
 }

--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -1,0 +1,40 @@
+package com.banno.vault
+
+import cats.effect.kernel.{Concurrent, Ref, Resource, Temporal}
+import cats.effect.syntax.all._
+import com.banno.vault.models._
+import io.circe.Decoder
+import org.http4s.Uri
+import org.http4s.client.Client
+import scala.concurrent.duration.FiniteDuration
+
+trait VaultClient[F[_]] {
+  def readSecret[A: Decoder](secretPath: String): F[VaultSecret[A]]
+}
+
+object VaultClient {
+  def apply[F[_]](implicit ev: VaultClient[F]): VaultClient[F] = ev
+
+  def login[F[_]](client: Client[F], vaultUri: Uri, roleId: String, tokenLeaseExtension: FiniteDuration)
+    (implicit F: Temporal[F]): Resource[F, VaultClient[F]] = {
+
+    def startRenewalStream(ref: Ref[F, VaultToken], token: VaultToken) =
+      Vault.tokenStream(client, vaultUri)(token, tokenLeaseExtension)
+        .evalMap(newToken => ref.set(newToken))
+        .compile
+        .drain
+        .start
+
+    for {
+      token <- Resource.make(Vault.login[F](client, vaultUri)(roleId))(Vault.revokeSelfToken(client, vaultUri))
+      tokenRef <- Resource.eval(Ref.of(token))
+      _ <- Resource.make(startRenewalStream(tokenRef, token))(_.cancel)
+    } yield impl(client, vaultUri, token)
+  }
+
+  private def impl[F[_]: Concurrent](client: Client[F], vaultUri: Uri, token: VaultToken): VaultClient[F] =
+    new VaultClient[F] {
+      def readSecret[A: Decoder](secretPath: String): F[VaultSecret[A]] =
+        Vault.readSecret(client, vaultUri)(token.clientToken, secretPath)
+    }
+}


### PR DESCRIPTION
Every function on `Vault` accepts the same two parameters, an HTTP client and a base URI.  Most require a token, which requires periodic refreshing.  That token is sometimes a `VaultToken`, sometimes a `String`.  Sometimes it's first in the second parameter list, sometimes it's last, sometimes it's in the first parameter list.

This provides a `VaultClient[F]` algebra that hid the token entirely.  The client is obtained as a resource by logging in, which spawns a fiber to keep the token current in a ref.  The client transparently manages the token, and revokes it when the resource is disposed.  The `VaultClient` does not break the existing `Vault` functions, and can be thought of as a higher-level access.