### PR TITLE
Adding a convenience method for login via k8s and keep secret leased.

### DIFF
--- a/core/src/main/scala/com/banno/vault/Vault.scala
+++ b/core/src/main/scala/com/banno/vault/Vault.scala
@@ -231,6 +231,11 @@ object Vault {
                                                 (roleId: String, secretPath: String, duration: FiniteDuration, waitInterval: FiniteDuration): Stream[F, A] =
     Stream.eval(login(client, vaultUri)(roleId)).flatMap(token => keepLoginAndSecretLeased[F, A](client, vaultUri)(token, secretPath, duration, waitInterval))
 
+  def loginK8sAndKeepSecretLeased[F[_]: Temporal, A: Decoder](client: Client[F], vaultUri: Uri)
+                                                (roleId: String, jwt: String,  secretPath: String, duration: FiniteDuration, waitInterval: FiniteDuration,  loginMountPoint: Uri.Path = path"/auth/kubernetes" ): Stream[F, A] =
+    Stream.eval(loginKubernetes(client, vaultUri)(roleId, jwt, loginMountPoint)).flatMap(token => keepLoginAndSecretLeased[F, A](client, vaultUri)(token, secretPath, duration, waitInterval))
+    
+
   /**
     * This function logs into the Vault server given by the vaultUri, to obtain a loginToken.
     *  It then also provides a Stream that continuously renews the token when it is about to finish.

--- a/core/src/test/scala/com/banno/vault/VaultSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultSpec.scala
@@ -497,4 +497,18 @@ class VaultSpec extends CatsEffectSuite with ScalaCheckEffectSuite with MissingP
         .assertEquals(Some(Left(Vault.InvalidRequirement("waitInterval longer than requested Lease Duration"))))
     }}
   }
+  test("loginK8sAndKeepSecretLeased fails when wait duration is longer than lease duration") {
+    PropF.forAllF(
+      VaultArbitraries.validVaultUri,
+      Arbitrary.arbitrary[FiniteDuration],
+      Arbitrary.arbitrary[FiniteDuration]
+    ) { case (uri, leaseDuration, waitInterval) => PropF.boolean[IO](leaseDuration < waitInterval) ==> {
+
+      Vault.loginK8sAndKeepSecretLeased[IO, Unit](mockClient, uri)(validRoleId, validKubernetesJwt, "",  leaseDuration, waitInterval)
+        .attempt
+        .compile
+        .last
+        .assertEquals(Some(Left(Vault.InvalidRequirement("waitInterval longer than requested Lease Duration"))))
+    }}
+  }
 }


### PR DESCRIPTION
Adds a companion for `loginAndKeepSecretLeased` that uses the `kubernetes` login. 