### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target core/target project/target
+        run: mkdir -p core/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target core/target project/target
+        run: tar cf targets.tar core/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val betterMonadicForV = "0.3.1"
 lazy val `vault4s` = project
   .in(file("."))
   .settings(publish / skip := true)
-  .disablePlugins(MimaPlugin)
+  .enablePlugins(NoPublishPlugin)
   .aggregate(core)
 
 lazy val core = project


### PR DESCRIPTION
When MiMa was disabled on the root module, that prevented `TypelevelSonatypeCiReleasePlugin` from adding the `tlCiRelease` command to `commands`, even though it was still generated into the YAML.

Now it's there:

```
sbt:vault4s> show commands
[info] core / commands
[info] 	List(SimpleCommand(git), SimpleCommand(sonatypeBundleRelease), SimpleCommand(sonatypeBundleUpload), SimpleCommand(sonatypePrepare), SimpleCommand(sonatypeOpen), SimpleCommand(sonatypeClose), SimpleCommand(sonatypePromote), SimpleCommand(sonatypeDrop), SimpleCommand(sonatypeRelease), SimpleCommand(sonatypeClean), SimpleCommand(sonatypeReleaseAll), SimpleCommand(sonatypeDropAll), SimpleCommand(sonatypeLog), SimpleCommand(sonatypeStagingRepositoryProfiles), SimpleCommand(sonatypeStagingProfiles), SimpleCommand(tlSonatypeBundleReleaseIfRelevant), SimpleCommand(tlCiRelease))
[info] commands
[info] 	List(SimpleCommand(git), SimpleCommand(sonatypeBundleRelease), SimpleCommand(sonatypeBundleUpload), SimpleCommand(sonatypePrepare), SimpleCommand(sonatypeOpen), SimpleCommand(sonatypeClose), SimpleCommand(sonatypePromote), SimpleCommand(sonatypeDrop), SimpleCommand(sonatypeRelease), SimpleCommand(sonatypeClean), SimpleCommand(sonatypeReleaseAll), SimpleCommand(sonatypeDropAll), SimpleCommand(sonatypeLog), SimpleCommand(sonatypeStagingRepositoryProfiles), SimpleCommand(sonatypeStagingProfiles), SimpleCommand(tlSonatypeBundleReleaseIfRelevant), SimpleCommand(tlCiRelease))
```

Fixes #354 