### PR TITLE
Ignore compile-time scope on dependency submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         uses: scalacenter/sbt-dependency-submission@v2
         with:
           modules-ignore: docs_2.12 docs_2.13 docs_3
-          configs-ignore: scala-doc-tool scala-tool test
+          configs-ignore: compile-time scala-doc-tool scala-tool test
 
   site:
     name: Generate Site

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ inThisBuild(
           name = Some("Submit Dependencies"),
           params = Map(
             "modules-ignore" -> "docs_2.12 docs_2.13 docs_3",
-            "configs-ignore" -> "scala-doc-tool scala-tool test"
+            "configs-ignore" -> "compile-time scala-doc-tool scala-tool test"
           )
         )
     ).copy(cond = Some("github.event_name != 'pull_request'"))


### PR DESCRIPTION
scalac-compat-0.1 via sbt-typelevel-0.5 is pulling in an old Scala 2 library.