### PR TITLE
Use the legacy Sonatype host

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ val Scala3 = "3.3.1"
 ThisBuild / crossScalaVersions := Seq("2.12.18", Scala213, Scala3)
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 ThisBuild / tlBaseVersion := "9.1"
+ThisBuild / tlSonatypeUseLegacyHost := true
 
 ThisBuild / githubWorkflowTargetBranches :=
   Seq("*", "series/*")


### PR DESCRIPTION
The next release tag will fail without this.