### PR TITLE
Support additional login types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val Scala213 = "2.13.16"
 val Scala3 = "3.3.5"
 ThisBuild / crossScalaVersions := Seq("2.12.20", Scala213, Scala3)
 ThisBuild / scalaVersion := crossScalaVersions.value.last
-ThisBuild / tlBaseVersion := "9.3"
+ThisBuild / tlBaseVersion := "9.4"
 ThisBuild / tlSonatypeUseLegacyHost := true
 
 ThisBuild / githubWorkflowTargetBranches :=
@@ -33,7 +33,7 @@ lazy val core = project
     name := "vault4s",
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core.IncompatibleSignatureProblem
-      import com.typesafe.tools.mima.core.ProblemFilters.exclude
+        import com.typesafe.tools.mima.core.ProblemFilters.exclude
       // See https://github.com/lightbend/mima/issues/423
       Seq(
       )

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val core = project
     name := "vault4s",
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core.IncompatibleSignatureProblem
-        import com.typesafe.tools.mima.core.ProblemFilters.exclude
+      import com.typesafe.tools.mima.core.ProblemFilters.exclude
       // See https://github.com/lightbend/mima/issues/423
       Seq(
       )

--- a/core/src/main/scala/com/banno/vault/Vault.scala
+++ b/core/src/main/scala/com/banno/vault/Vault.scala
@@ -158,6 +158,28 @@ object Vault {
     } yield token
   }
 
+  /** https://developer.hashicorp.com/vault/api-docs/auth/userpass
+    */
+  def loginUserPass[F[_]](client: Client[F], vaultUri: Uri)(
+      username: String,
+      password: String
+  )(implicit F: Concurrent[F]): F[VaultToken] = {
+    val request = Request[F](
+      method = Method.POST,
+      uri = vaultUri / "v1" / "auth" / "userpass" / "login" / username
+    ).withEntity(Json.obj("password" := password))
+    for {
+      json <- F.handleErrorWith(client.expect[Json](request)) { e =>
+        F.raiseError(
+          VaultRequestError(request, e.some, s"username=$username".some)
+        )
+      }
+      token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
+        decoderError
+      )
+    } yield token
+  }
+
   /** https://www.vaultproject.io/api/secret/kv/index.html#read-secret
     */
   def readSecret[F[_], A](client: Client[F], vaultUri: Uri)(

--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -247,6 +247,8 @@ object VaultClient {
             k8s.jwt,
             k8s.mountPoint
           )
+        case gitHub: VaultConfig.GitHub =>
+          Vault.loginGitHub(client, gitHub.vaultUri)(gitHub.gitHubToken)
       }
     )
 

--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -256,6 +256,8 @@ object VaultClient {
           )
         case gitHub: VaultConfig.GitHub =>
           Vault.loginGitHub(client, gitHub.vaultUri)(gitHub.gitHubToken)
+        case uap: VaultConfig.UsernameAndPassword =>
+          Vault.loginUserPass(client, uap.vaultUri)(uap.username, uap.username)
       }
     )
 

--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -240,7 +240,14 @@ object VaultClient {
       leaseConfig,
       vaultConfig match {
         case role: VaultConfig.AppRole =>
-          Vault.login(client, role.vaultUri)(role.roleId)
+          role.secretId match {
+            case None => Vault.login(client, role.vaultUri)(role.roleId)
+            case Some(secretId) =>
+              Vault.loginAppRoleAndSecretId(client, role.vaultUri)(
+                role.roleId,
+                secretId
+              )
+          }
         case k8s: VaultConfig.K8s =>
           Vault.loginKubernetes(client, k8s.vaultUri)(
             k8s.roleId,

--- a/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
@@ -77,6 +77,19 @@ object VaultConfig {
   ): VaultConfig.GitHub =
     new GitHubImpl(vaultUri, gitHubToken, tokenLeaseExtension)
 
+  def usernameAndPassword(
+      vaultUri: Uri,
+      username: String,
+      password: String,
+      tokenLeaseExtension: FiniteDuration
+  ): VaultConfig.UsernameAndPassword =
+    new UsernameAndPasswordImpl(
+      vaultUri,
+      username,
+      password,
+      tokenLeaseExtension
+    )
+
   sealed trait AppRole extends VaultConfig {
     override def roleId: String
     def secretId: Option[String] = None

--- a/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
@@ -120,6 +120,13 @@ object VaultConfig {
       override val secretId: Option[String],
       override val tokenLeaseExtension: FiniteDuration
   ) extends AppRole {
+    def this(
+        _vaultUri: Uri,
+        _roleId: String,
+        _tokenLeaseExtension: FiniteDuration
+    ) =
+      this(_vaultUri, _roleId, None, _tokenLeaseExtension)
+
     override def withTokenLeaseExtension(
         extension: FiniteDuration
     ): AppRole =

--- a/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
@@ -92,6 +92,14 @@ object VaultConfig {
     def gitHubToken: String
     override def withTokenLeaseExtension(extension: FiniteDuration): GitHub
   }
+  sealed trait UsernameAndPassword extends VaultConfig {
+    def username: String
+    def password: String
+
+    override def withTokenLeaseExtension(
+        extension: FiniteDuration
+    ): UsernameAndPassword
+  }
 
   private final class AppRoleImpl(
       override val vaultUri: Uri,
@@ -129,5 +137,19 @@ object VaultConfig {
       new GitHubImpl(vaultUri, roleId, extension)
 
     override protected def roleId: String = gitHubToken
+  }
+
+  private final class UsernameAndPasswordImpl(
+      override val vaultUri: Uri,
+      override val username: String,
+      override val password: String,
+      override val tokenLeaseExtension: FiniteDuration
+  ) extends UsernameAndPassword {
+    override def withTokenLeaseExtension(
+        extension: FiniteDuration
+    ): UsernameAndPassword =
+      new UsernameAndPasswordImpl(vaultUri, username, password, extension)
+
+    override protected def roleId: String = username
   }
 }

--- a/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultConfig.scala
@@ -33,7 +33,15 @@ object VaultConfig {
       roleId: String,
       tokenLeaseExtension: FiniteDuration
   ): VaultConfig.AppRole =
-    new AppRoleImpl(vaultUri, roleId, tokenLeaseExtension)
+    new AppRoleImpl(vaultUri, roleId, None, tokenLeaseExtension)
+
+  def appRole(
+      vaultUri: Uri,
+      roleId: String,
+      secretId: String,
+      tokenLeaseExtension: FiniteDuration
+  ): VaultConfig.AppRole =
+    new AppRoleImpl(vaultUri, roleId, Some(secretId), tokenLeaseExtension)
 
   def k8s(
       vaultUri: Uri,
@@ -71,6 +79,7 @@ object VaultConfig {
 
   sealed trait AppRole extends VaultConfig {
     override def roleId: String
+    def secretId: Option[String] = None
     override def withTokenLeaseExtension(extension: FiniteDuration): AppRole
   }
   sealed trait K8s extends VaultConfig {
@@ -87,12 +96,13 @@ object VaultConfig {
   private final class AppRoleImpl(
       override val vaultUri: Uri,
       override val roleId: String,
+      override val secretId: Option[String],
       override val tokenLeaseExtension: FiniteDuration
   ) extends AppRole {
     override def withTokenLeaseExtension(
         extension: FiniteDuration
     ): AppRole =
-      new AppRoleImpl(vaultUri, roleId, extension)
+      new AppRoleImpl(vaultUri, roleId, secretId, extension)
   }
 
   private final class K8sImpl(


### PR DESCRIPTION
Adds support for:
- GitHub token (I needed this for local development)
- Username and Password (resurrects #405)
- AppRole with secret_id (resurrects #303)

Fixes #302 