### PR TITLE
Report API errors in generated exceptions

### DIFF
--- a/core/src/main/scala/com/banno/vault/Vault.scala
+++ b/core/src/main/scala/com/banno/vault/Vault.scala
@@ -22,7 +22,7 @@ import cats.syntax.all.*
 import com.banno.vault.models.*
 import fs2.Stream
 import io.circe.syntax.*
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import io.circe.*
 import org.http4s.*
 import org.http4s.circe.*
 import org.http4s.client.*
@@ -54,14 +54,12 @@ object Vault {
       method = Method.POST,
       uri = vaultUri / "v1" / "auth" / "approle" / "login"
     ).withEntity(Json.obj(("role_id", Json.fromString(roleId))))
-    for {
-      json <- F.handleErrorWith(client.expect[Json](request)) { e =>
-        F.raiseError(VaultRequestError(request, e.some, s"roleId=$roleId".some))
-      }
-      token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
-        decoderError
-      )
-    } yield token
+
+    decodeLoginOrFail[F](
+      request,
+      client.run(request),
+      s"roleId=$roleId".some
+    )
   }
 
   /** https://www.vaultproject.io/api/auth/approle/index.html#login-with-approle
@@ -79,20 +77,12 @@ object Vault {
         "secret_id" := secretId
       )
     )
-    for {
-      json <- F.handleErrorWith(client.expect[Json](request)) { e =>
-        F.raiseError(
-          VaultRequestError(
-            request,
-            e.some,
-            s"roleId=$roleId, secretId=XXXX".some
-          )
-        )
-      }
-      token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
-        decoderError
-      )
-    } yield token
+
+    decodeLoginOrFail[F](
+      request,
+      client.run(request),
+      s"roleId=$roleId, secretId=XXXX".some
+    )
   }
 
   /** https://www.vaultproject.io/api/auth/kubernetes/index.html#login
@@ -115,16 +105,12 @@ object Vault {
         ("jwt", Json.fromString(jwt))
       )
     )
-    for {
-      json <- F.handleErrorWith(client.expect[Json](request)) { e =>
-        F.raiseError(
-          VaultRequestError(request, e.some, s"role=$role".some)
-        ) // don't expose jwt in error
-      }
-      token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
-        decoderError
-      )
-    } yield token
+
+    decodeLoginOrFail[F](
+      request,
+      client.run(request),
+      s"role=$role".some // don't expose jwt in error
+    )
   }
 
   /** https://www.vaultproject.io/api/auth/kubernetes/index.html#login
@@ -148,14 +134,12 @@ object Vault {
       method = Method.POST,
       uri = vaultUri / "v1" / "auth" / "github" / "login"
     ).withEntity(Json.obj(("token", Json.fromString(token))))
-    for {
-      json <- F.handleErrorWith(client.expect[Json](request)) { e =>
-        F.raiseError(VaultRequestError(request, e.some, none))
-      }
-      token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
-        decoderError
-      )
-    } yield token
+
+    decodeLoginOrFail[F](
+      request,
+      client.run(request),
+      none // don't expose token in error
+    )
   }
 
   /** https://developer.hashicorp.com/vault/api-docs/auth/userpass
@@ -168,16 +152,12 @@ object Vault {
       method = Method.POST,
       uri = vaultUri / "v1" / "auth" / "userpass" / "login" / username
     ).withEntity(Json.obj("password" := password))
-    for {
-      json <- F.handleErrorWith(client.expect[Json](request)) { e =>
-        F.raiseError(
-          VaultRequestError(request, e.some, s"username=$username".some)
-        )
-      }
-      token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
-        decoderError
-      )
-    } yield token
+
+    decodeLoginOrFail[F](
+      request,
+      client.run(request),
+      s"username=$username".some // don't expose password in error
+    )
   }
 
   /** https://www.vaultproject.io/api/secret/kv/index.html#read-secret
@@ -193,19 +173,15 @@ object Vault {
       uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/$newSecretPath")),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
     )
-    F.adaptError(
-      client.expect[VaultSecret[A]](request)(jsonOf[F, VaultSecret[A]])
-    ) { case InvalidMessageBodyFailure(_, Some(cause: DecodingFailure)) =>
-      InvalidMessageBodyFailure("Could not decode secret key value", cause.some)
-    }.handleErrorWith { e =>
-      F.raiseError(
-        VaultRequestError(
-          request = request,
-          cause = e.some,
-          extra = s"tokenLength=${token.length}".some
-        )
-      )
-    }
+
+    decodeResponseOrFail[F, VaultSecret[A]](
+      request,
+      client.run(request),
+      _.hcursor,
+      s"tokenLength=${token.length}".some,
+      df =>
+        InvalidMessageBodyFailure("Could not decode secret key value", df.some)
+    )
   }
 
   /** https://www.vaultproject.io/api/secret/kv/kv-v1#list-secrets uses GET
@@ -224,19 +200,18 @@ object Vault {
         .withQueryParam("list", "true"),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
     )
-    F.adaptError(client.expect[VaultKeys](request)(jsonOf[F, VaultKeys])) {
-      case InvalidMessageBodyFailure(_, Some(cause: DecodingFailure)) =>
+
+    decodeResponseOrFail[F, VaultKeys](
+      request,
+      client.run(request),
+      _.hcursor,
+      s"tokenLength=${token.length}".some,
+      df =>
         InvalidMessageBodyFailure(
           "Could not decode vault list secrets response",
-          cause.some
+          df.some
         )
-      case e =>
-        VaultRequestError(
-          request = request,
-          cause = e.some,
-          extra = s"tokenLength=${token.length}".some
-        )
-    }
+    )
   }
 
   /** https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#delete-secret
@@ -252,19 +227,10 @@ object Vault {
       uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/$newSecretPath")),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
     )
+
     client
-      .status(request)
-      .ensureOr(UnexpectedStatus(_, request.method, request.uri))(_.isSuccess)
-      .handleErrorWith { e =>
-        F.raiseError(
-          VaultRequestError(
-            request,
-            e.some,
-            s"tokenLength=${token.length}".some
-          )
-        )
-      }
-      .void
+      .run(request)
+      .use(expectSuccessOrFail(request, _, s"tokenLength=${token.length}".some))
   }
 
   /** https://www.vaultproject.io/api/system/leases.html#renew-lease
@@ -285,21 +251,18 @@ object Vault {
         ("increment", Json.fromLong(newLeaseDuration.toSeconds))
       )
     )
-    for {
-      renewal <- F.handleErrorWith(
-        client.expect[VaultSecretRenewal](request)(
-          jsonOf[F, VaultSecretRenewal]
+
+    decodeResponseOrFail[F, VaultSecretRenewal](
+      request,
+      client.run(request),
+      _.hcursor,
+      s"tokenLength=${token.length}".some,
+      df =>
+        InvalidMessageBodyFailure(
+          "Could not decode vault lease renew response",
+          df.some
         )
-      ) { e =>
-        F.raiseError(
-          VaultRequestError(
-            request = request,
-            cause = e.some,
-            extra = s"tokenLength=${token.length}".some
-          )
-        )
-      }
-    } yield renewal
+    )
   }
 
   /** https://developer.hashicorp.com/vault/api-docs/auth/token#renew-a-token-self
@@ -309,7 +272,7 @@ object Vault {
       newLeaseDuration: FiniteDuration
   )(implicit F: Concurrent[F]): F[VaultToken] =
     if (!token.renewable)
-      new NonRenewableToken(token.clientToken).raiseError[F, VaultToken]
+      NonRenewableToken(token.clientToken).raiseError[F, VaultToken]
     else {
       val request = Request[F](
         method = Method.POST,
@@ -321,20 +284,18 @@ object Vault {
           ("increment", Json.fromString(s"${newLeaseDuration.toSeconds}s"))
         )
       )
-      for {
-        json <- F.handleErrorWith(client.expect[Json](request)) { e =>
-          F.raiseError(
-            VaultRequestError(
-              request,
-              e.some,
-              s"tokenLength=${token.clientToken.length}".some
-            )
+
+      decodeResponseOrFail[F, VaultToken](
+        request,
+        client.run(request),
+        _.hcursor.downField("auth"),
+        s"tokenLength=${token.clientToken.length}".some,
+        df =>
+          InvalidMessageBodyFailure(
+            "Could not decode vault token renew response",
+            df.some
           )
-        }
-        token <- raiseKnownError(json.hcursor.get[VaultToken]("auth"))(
-          decoderError
-        )
-      } yield token
+      )
     }
 
   /** https://www.vaultproject.io/api/auth/token/index.html#revoke-a-token-self-
@@ -348,19 +309,16 @@ object Vault {
       headers =
         Headers(Header.Raw(CIString("X-Vault-Token"), token.clientToken))
     )
-    val resp = client
-      .status(request)
-      .ensureOr(UnexpectedStatus(_, request.method, request.uri))(_.isSuccess)
-      .void
-    F.handleErrorWith(resp) { e =>
-      F.raiseError(
-        VaultRequestError(
+
+    client
+      .run(request)
+      .use(
+        expectSuccessOrFail(
           request,
-          e.some,
+          _,
           s"tokenLength=${token.clientToken.length}".some
         )
       )
-    }
   }
 
   /** https://www.vaultproject.io/api/system/leases.html#revoke-lease
@@ -375,20 +333,16 @@ object Vault {
         vaultUri.withPath(Uri.Path.unsafeFromString("/v1/sys/leases/revoke")),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), clientToken))
     ).withEntity(Json.obj("lease_id" -> Json.fromString(leaseId)))
-    for {
-      _ <- client
-        .status(request)
-        .ensureOr(UnexpectedStatus(_, request.method, request.uri))(_.isSuccess)
-        .handleErrorWith { e =>
-          F.raiseError(
-            VaultRequestError(
-              request,
-              e.some,
-              s"tokenLength=${clientToken.length}".some
-            )
-          )
-        }
-    } yield ()
+
+    client
+      .run(request)
+      .use(
+        expectSuccessOrFail(
+          request,
+          _,
+          s"tokenLength=${clientToken.length}".some
+        )
+      )
   }
 
   /** https://www.vaultproject.io/api/secret/pki/index.html#generate-certificate
@@ -414,38 +368,28 @@ object Vault {
       uri = vaultUri.withPath(Uri.Path.unsafeFromString(s"/v1/$newSecretPath")),
       headers = Headers(Header.Raw(CIString("X-Vault-Token"), token))
     )
-    val withBody = request.withEntity(payload.asJson)
-    client.run(withBody).use {
-      case resp @ Status.Successful(_) =>
-        resp
-          .attemptAs[VaultSecret[B]](jsonOf[F, VaultSecret[B]])
-          .adaptError {
-            case InvalidMessageBodyFailure(_, Some(cause: DecodingFailure)) =>
-              InvalidMessageBodyFailure(
-                "Could not decode secret key value",
-                cause.some
-              )
+
+    decodeResponseOrFailOpt[F, VaultSecret[B]](
+      request,
+      client.run(request.withEntity(payload.asJson)),
+      _.hcursor,
+      s"tokenLength=${token.length}".some,
+      df =>
+        InvalidMessageBodyFailure("Could not decode secret key value", df.some)
+    ).flatMap {
+      case Some(vs) => vs.pure[F]
+      case None =>
+        readSecret[F, B](client, vaultUri)(token, secretPath)
+          .adaptError { case readError =>
+            readError.addSuppressed(
+              UnexpectedStatus(Status.NoContent, request.method, request.uri)
+            )
+            VaultRequestError(
+              request = request,
+              cause = readError.some,
+              extra = s"tokenLength=${token.length}".some
+            )
           }
-          .valueOrF { decodeError =>
-            readSecret[F, B](client, vaultUri)(token, secretPath)
-              .adaptError { case readError =>
-                decodeError.addSuppressed(readError)
-                VaultRequestError(
-                  request = withBody,
-                  cause = decodeError.some,
-                  extra = s"tokenLength=${token.length}".some
-                )
-              }
-          }
-      case resp =>
-        F.raiseError(
-          VaultRequestError(
-            request = withBody,
-            cause =
-              UnexpectedStatus(resp.status, request.method, request.uri).some,
-            extra = s"tokenLength=${token.length}".some
-          )
-        )
     }
   }
 
@@ -960,10 +904,117 @@ object Vault {
         s"Could not decode JSON, error: ${failure.message}, cursor: ${failure.history}"
       )
 
-  private[this] def raiseKnownError[F[_], E1, E2 <: Throwable, A](
-      e: Either[E1, A]
-  )(errorF: E1 => E2)(implicit F: Concurrent[F]): F[A] =
-    F.fromEither(e.leftMap(errorF))
+  private[this] def decodeResponseOrFailOpt[F[_]: Concurrent, A: Decoder](
+      request: Request[F],
+      responseR: Resource[F, Response[F]],
+      toCursor: Json => ACursor,
+      extra: Option[String],
+      fmtDecoderFailure: DecodingFailure => DecodeFailure
+  ): F[Option[A]] =
+    responseR.use { response =>
+      if (response.status === Status.NoContent)
+        none.pure[F]
+      else if (response.status.isSuccess)
+        response.json
+          .adaptError { case e => VaultRequestError(request, e.some, extra) }
+          .flatMap { json =>
+            toCursor(json)
+              .as[A]
+              .leftFlatMap { e =>
+                VaultApiError
+                  .decode(response.status, json)
+                  .fold(
+                    _ => fmtDecoderFailure(e).asLeft[A],
+                    vae =>
+                      Left {
+                        if (vae.errors.nonEmpty) vae
+                        else fmtDecoderFailure(e)
+                      }
+                  )
+              }
+              .bimap(
+                cause => VaultRequestError(request, cause.some, extra),
+                _.some
+              )
+              .liftTo[F]
+          }
+      else
+        response.json.flatMap { json =>
+          val cause = VaultApiError
+            .decode(response.status, json)
+            .valueOr(fmtDecoderFailure(_))
+
+          VaultRequestError(request, cause.some, extra).raiseError[F, Option[A]]
+        }
+    }
+
+  private[this] def decodeResponseOrFail[F[_]: Concurrent, A: Decoder](
+      request: Request[F],
+      responseR: Resource[F, Response[F]],
+      toCursor: Json => ACursor,
+      extra: Option[String],
+      fmtDecoderFailure: DecodingFailure => DecodeFailure
+  ): F[A] =
+    decodeResponseOrFailOpt[F, A](
+      request,
+      responseR,
+      toCursor,
+      extra,
+      fmtDecoderFailure
+    )
+      .flatMap(_.liftTo[F] {
+        VaultRequestError(
+          request,
+          UnexpectedStatus(Status.NoContent, request.method, request.uri).some,
+          extra
+        )
+      })
+
+  private[this] def decodeLoginOrFail[F[_]: Concurrent](
+      request: Request[F],
+      response: Resource[F, Response[F]],
+      extra: Option[String]
+  ): F[VaultToken] =
+    decodeResponseOrFail[F, VaultToken](
+      request,
+      response,
+      _.hcursor.downField("auth"),
+      extra,
+      decoderError
+    )
+
+  private[this] def expectSuccessOrFail[F[_]: Concurrent](
+      request: Request[F],
+      response: Response[F],
+      extra: Option[String]
+  ): F[Unit] =
+    if (response.status.isSuccess) Applicative[F].unit
+    else {
+      val unexpectedStatus =
+        UnexpectedStatus(response.status, request.method, request.uri)
+      response.json
+        .adaptError { case e =>
+          unexpectedStatus.addSuppressed(e)
+          VaultRequestError(request, unexpectedStatus.some, extra)
+        }
+        .flatMap { json =>
+          VaultApiError
+            .decode(response.status, json)
+            .fold(
+              df => {
+                unexpectedStatus.addSuppressed(df)
+                VaultRequestError(request, unexpectedStatus.some, extra)
+              },
+              vae => {
+                if (vae.errors.nonEmpty)
+                  VaultRequestError(request, vae.some, extra)
+                else
+                  VaultRequestError(request, unexpectedStatus.some, extra)
+              }
+            )
+            .raiseError[F, Unit]
+        }
+    }
 
   final case class InvalidRequirement(message: String) extends Throwable {
     override def getMessage(): String = message

--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -284,19 +284,17 @@ object VaultClient {
     retryUntilConsistent(
       leaseConfig,
       Vault.revokeSelfToken(client, vaultConfig.vaultUri)(vaultToken)
-    )
-      .attemptTap(_.leftTraverse(t => Async[F].delay(println(t))))
-      .recoverWith {
-        case VaultRequestError(
-              _,
-              Some(
-                UnexpectedStatus(Status.Forbidden, _, _) |
-                VaultApiError(Status.Forbidden, _)
-              )
-            ) =>
-          // This means the token has already expired or been revoked, so we can ignore this
-          Async[F].unit
-      }
+    ).recoverWith {
+      case VaultRequestError(
+            _,
+            Some(
+              UnexpectedStatus(Status.Forbidden, _, _) |
+              VaultApiError(Status.Forbidden, _)
+            )
+          ) =>
+        // This means the token has already expired or been revoked, so we can ignore this
+        Async[F].unit
+    }
 
   private class Default[F[_]: Async](
       client: Client[F],

--- a/core/src/main/scala/com/banno/vault/models/VaultApiError.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultApiError.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.banno.vault.models
 
 import io.circe.{DecodingFailure, Json}

--- a/core/src/main/scala/com/banno/vault/models/VaultApiError.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultApiError.scala
@@ -1,0 +1,21 @@
+package com.banno.vault.models
+
+import io.circe.{DecodingFailure, Json}
+import org.http4s.Status
+
+import scala.util.control.NoStackTrace
+
+final case class VaultApiError(status: Status, errors: List[String])
+    extends RuntimeException(errors.mkString("Vault API Errors:\n", "\n", ""))
+    with NoStackTrace
+
+object VaultApiError {
+  def decode(
+      status: Status,
+      json: Json
+  ): Either[DecodingFailure, VaultApiError] =
+    json.hcursor
+      .downField("errors")
+      .as[List[String]]
+      .map(VaultApiError(status, _))
+}

--- a/core/src/main/scala/com/banno/vault/models/VaultRequestError.scala
+++ b/core/src/main/scala/com/banno/vault/models/VaultRequestError.scala
@@ -41,9 +41,8 @@ object VaultRequestError {
   ): String = {
     val extraString = extra.map(e => s", $e").getOrElse("")
     val requestString: String =
-      s"""Error on request: Request(method=${request.method}, uri=${request.uri
-          .toString()}$extraString)"""
-    s"$requestString ${cause map (c => s"\nCause: ${c.getMessage}") getOrElse ""}"
+      s"""Error on request: Request(method=${request.method}, uri=${request.uri.renderString}$extraString)"""
+    s"$requestString${cause map (c => s"\nCause: ${c.getMessage}") getOrElse ""}"
   }
 
 }

--- a/core/src/test/scala/com/banno/vault/VaultClientSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultClientSpec.scala
@@ -26,7 +26,8 @@ import com.banno.vault.VaultClient.CurrentlyInconsistent
 import com.banno.vault.models.{
   ConsistencyConfig,
   VaultConfig,
-  VaultRequestError
+  VaultRequestError,
+  VaultApiError
 }
 import io.circe.Json
 import munit.catseffect.IOFixture
@@ -118,6 +119,8 @@ class VaultClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
                           _,
                           Some(UnexpectedStatus(status, _, _))
                         ) =>
+                      status.pure[IO]
+                    case VaultRequestError(_, Some(VaultApiError(status, _))) =>
                       status.pure[IO]
                     case e => IO.raiseError(e)
                   })


### PR DESCRIPTION
This is best-effort, so downstream should probably not build logic around it. Hopefully this will make logs more useful.

Fixes #345