### PR TITLE
Do not revoke tokens that have been provided

### DIFF
--- a/core/src/main/scala/com/banno/vault/VaultClient.scala
+++ b/core/src/main/scala/com/banno/vault/VaultClient.scala
@@ -305,19 +305,26 @@ object VaultClient {
       vaultConfig: VaultConfig,
       leaseConfig: ConsistencyConfig
   ): F[Unit] =
-    retryUntilConsistent(
-      leaseConfig,
-      Vault.revokeSelfToken(client, vaultConfig.vaultUri)(vaultToken)
-    ).recoverWith {
-      case VaultRequestError(
-            _,
-            Some(
-              UnexpectedStatus(Status.Forbidden, _, _) |
-              VaultApiError(Status.Forbidden, _)
-            )
-          ) =>
-        // This means the token has already expired or been revoked, so we can ignore this
-        Async[F].unit
+    vaultConfig match {
+      case _: VaultConfig.ProvidedVaultToken =>
+        // If a token was provided, rather than something the client got by logging in,
+        // we don't want to revoke it.
+        Applicative[F].unit
+      case _ =>
+        retryUntilConsistent(
+          leaseConfig,
+          Vault.revokeSelfToken(client, vaultConfig.vaultUri)(vaultToken)
+        ).recoverWith {
+          case VaultRequestError(
+                _,
+                Some(
+                  UnexpectedStatus(Status.Forbidden, _, _) |
+                  VaultApiError(Status.Forbidden, _)
+                )
+              ) =>
+            // This means the token has already expired or been revoked, so we can ignore this
+            Async[F].unit
+        }
     }
 
   private def recoverVaultRequestWithRevokeAndRetry[F[

--- a/core/src/test/scala/com/banno/vault/VaultClientSpec.scala
+++ b/core/src/test/scala/com/banno/vault/VaultClientSpec.scala
@@ -96,6 +96,44 @@ class VaultClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
     TestControl.executeEmbed(program).assert
   }
 
+  test("VaultClient.loginOnce won't revoke the token if provided") {
+    val program =
+      for {
+        _ <- mockService.addRoles(role -> renewable(1.minute))
+        _ <- mockService.addV1Secrets(path"foo" -> Secret(role :: Nil, 5))
+        token <- Vault.loginKubernetes(
+          mockService.client,
+          vaultConfig.vaultUri
+        )(
+          vaultConfig.roleId,
+          vaultConfig.jwt,
+          vaultConfig.mountPoint
+        )
+        config = VaultConfig.providedVaultToken(
+          vaultConfig.vaultUri,
+          token,
+          vaultConfig.tokenLeaseExtension
+        )
+        _ <-
+          VaultClient
+            .loginOnce[IO](mockService.client, config, consistencyConfig)
+            .use(_.readSecret[Int]("secret/foo").map(_.data))
+            .assertEquals(5)
+        _ <- mockService.logs.assertEquals(
+          Vector(
+            Login(path"/v1/auth/kubernetes/login", role, s"$roleLogId token 0"),
+            SecretViewed(
+              path"/v1/secret/foo",
+              s"$roleLogId token 0",
+              path"foo"
+            )
+          )
+        )
+      } yield ()
+
+    TestControl.executeEmbed(program).assert
+  }
+
   test("VaultClient.loginOnce won't renew the token") {
     val program =
       for {
@@ -168,6 +206,48 @@ class VaultClientSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
             TokenRevoked(
               path"/v1/auth/token/revoke-self",
               s"$roleLogId token 0"
+            )
+          )
+        )
+      } yield ()
+
+    TestControl.executeEmbed(program).assert
+  }
+
+  test("VaultClient.loginAndKeep won't revoke the token if provided") {
+    val program =
+      for {
+        _ <- mockService.addRoles(role -> renewable(1.minute))
+        _ <- mockService.addV1Secrets(path"foo" -> Secret(role :: Nil, 5))
+        token <- Vault.loginKubernetes(
+          mockService.client,
+          vaultConfig.vaultUri
+        )(
+          vaultConfig.roleId,
+          vaultConfig.jwt,
+          vaultConfig.mountPoint
+        )
+        config = VaultConfig.providedVaultToken(
+          vaultConfig.vaultUri,
+          token,
+          vaultConfig.tokenLeaseExtension
+        )
+        _ <-
+          VaultClient
+            .loginAndKeep[IO](
+              mockService.client,
+              config,
+              consistencyConfig
+            )
+            .use(_.readSecret[Int]("secret/foo").map(_.data))
+            .assertEquals(5)
+        _ <- mockService.logs.assertEquals(
+          Vector(
+            Login(path"/v1/auth/kubernetes/login", role, s"$roleLogId token 0"),
+            SecretViewed(
+              path"/v1/secret/foo",
+              s"$roleLogId token 0",
+              path"foo"
             )
           )
         )


### PR DESCRIPTION
Turns out it breaks local development to have to have your token unexpectedly revoked. Oops